### PR TITLE
Added teleport-bootstrap-script module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,34 @@ module "security_groups_teleport" {
   vpc_id = "${module.vpc.vpc_id}"
 }
 ```
+
+## teleport-bootstrap-script
+
+This module creates a script to configure and start the Teleport service on a server. It's useful on pre-built images, where everything is already setup on build-time but Teleport still needs to be configured with the actual node information, like private IP, node name and `auth` credentials. It uses `envsubst` to set the correct configuration into `/etc/teleport.yaml`, so the following environment variables need to be present in that file before running this script:
+
+- `$ADVERTISE_IP`
+- `$AUTH_TOKEN`
+- `$AUTH_SERVER`
+- `$NODENAME`
+
+### Available variables:
+* [`auth_server`]: String(required): Auth server that this node will connect to, including the port number.
+* [`auth_token`]: String(required): Auth token that this node will present to the auth server.
+* [`function`]: String(required): Function that this node performs, will be the first part of the node name.
+* [`project`]: String(optional): Project where this node belongs to, will be the second part of the node name. Defaults to ''
+* [`environment`]: String(optional): Environment where this node belongs to, will be the third part of the node name. Defaults to ''
+* [`include_instance_id`]: String(optional): If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled. Defaults to true
+
+### Output
+ * [`teleport_bootstrap_script`]: String: The rendered script to add to the Instance cloud-init user data.
+
+### Example
+```
+module "teleport_bootstrap_script" {
+  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=1.0.0"
+  auth_server = "tools01.customer.skyscrape.rs:3025"
+  auth_token  = "something_really_really_secret"
+  function    = "api"
+  environment = "${terraform.workspace}"
+}
+```

--- a/teleport-bootstrap-script/main.tf
+++ b/teleport-bootstrap-script/main.tf
@@ -1,0 +1,12 @@
+data "template_file" "teleport_bootstrap_script" {
+  template = "${file("${path.module}/metadata.tpl")}"
+
+  vars {
+    function            = "${var.function}"
+    project             = "${var.project == "" ? "" : "-${var.project}"}"
+    environment         = "${var.environment == "" ? "" : "-${var.environment}"}"
+    include_instance_id = "${var.include_instance_id}"
+    auth_token          = "${var.auth_token}"
+    auth_server         = "${var.auth_server}"
+  }
+}

--- a/teleport-bootstrap-script/metadata.tpl
+++ b/teleport-bootstrap-script/metadata.tpl
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+# Config /etc/teleport
+
+## Get private IP for advertise_ip
+export ADVERTISE_IP="$(ip addr show eth0 | grep 'inet ' | awk '{print $2}' | cut -f1 -d'/')"
+
+## Get instance ID (if possible)
+${include_instance_id == "true" ? "export INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)" : ""}
+
+## Set the rest of the config
+export AUTH_TOKEN=${auth_token}
+export AUTH_SERVER=${auth_server}
+export NODENAME=${function}${project}${environment}$INSTANCE_ID
+
+envsubst < "/etc/teleport.yaml" > "/etc/teleport_new.yaml"
+mv /etc/teleport_new.yaml /etc/teleport.yaml
+
+# Enable teleport service
+sudo systemctl enable teleport.service
+
+# Start teleport service
+sudo systemctl start teleport.service

--- a/teleport-bootstrap-script/outputs.tf
+++ b/teleport-bootstrap-script/outputs.tf
@@ -1,0 +1,3 @@
+output "teleport_bootstrap_script" {
+  value = ["${data.template_file.teleport_bootstrap_script.rendered}"]
+}

--- a/teleport-bootstrap-script/variables.tf
+++ b/teleport-bootstrap-script/variables.tf
@@ -1,0 +1,26 @@
+variable "auth_server" {
+  description = "Auth server that this node will connect to, including the port number"
+}
+
+variable "auth_token" {
+  description = "Auth token that this node will present to the auth server."
+}
+
+variable "function" {
+  description = "Function that this node performs, will be the first part of the node name."
+}
+
+variable "project" {
+  description = "Project where this node belongs to, will be the second part of the node name. Defaults to ''"
+  default     = ""
+}
+
+variable "environment" {
+  description = "Environment where this node belongs to, will be the third part of the node name. Defaults to ''"
+  default     = ""
+}
+
+variable "include_instance_id" {
+  description = "If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled. Defaults to true"
+  default     = "true"
+}


### PR DESCRIPTION
## teleport-bootstrap-script

This module creates a script to configure and start the Teleport service on a server. It's useful on pre-built images, where everything is already setup on build-time but Teleport still needs to be configured with the actual node information, like private IP, node name and `auth` credentials.