### PR TITLE
Run teleport on ECS

### DIFF
--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -31,7 +31,7 @@ resource "aws_route53_record" "teleport" {
   }
 }
 
-resource "aws_route53_record" "teleport" {
+resource "aws_route53_record" "teleport_tsh" {
   count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
   name    = "tsh.${var.domain_name}"

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -13,6 +13,11 @@ data "aws_lb" "alb" {
   arn   = "${data.aws_lb_listener.alb.load_balancer_arn}"
 }
 
+data "aws_lb" "nlb" {
+  count = "${var.create_dns_record ? 1 : 0}"
+  arn   = "${var.nlb_arn}"
+}
+
 resource "aws_route53_record" "teleport" {
   count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
@@ -22,6 +27,19 @@ resource "aws_route53_record" "teleport" {
   alias {
     name                   = "${data.aws_lb.alb.dns_name}"
     zone_id                = "${data.aws_lb.alb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "teleport" {
+  count   = "${var.create_dns_record ? 1 : 0}"
+  zone_id = "${data.aws_route53_zone.teleport.zone_id}"
+  name    = "tsh.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_lb.nlb.dns_name}"
+    zone_id                = "${data.aws_lb.nlb.zone_id}"
     evaluate_target_health = true
   }
 }

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -1,0 +1,23 @@
+data "aws_route53_zone" "teleport" {
+  name         = "${var.domain_name}."
+}
+
+data "aws_lb_listener" "alb" {
+  arn = "${var.alb_listener_arn}"
+}
+
+data "aws_lb" "alb" {
+  arn  = "${data.aws_lb_listener.alb.load_balancer_arn}"
+}
+
+resource "aws_route53_record" "teleport" {
+  zone_id = "${data.aws_route53_zone.teleport.zone_id}"
+  name    = "teleport.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_lb.alb.dns_name}"
+    zone_id                = "${data.aws_lb.alb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -1,16 +1,20 @@
 data "aws_route53_zone" "teleport" {
-  name         = "${var.domain_name}."
+  count = "${var.create_dns_record ? 1 : 0}"
+  name  = "${var.domain_name}."
 }
 
 data "aws_lb_listener" "alb" {
-  arn = "${var.alb_listener_arn}"
+  count = "${var.create_dns_record ? 1 : 0}"
+  arn   = "${var.alb_listener_arn}"
 }
 
 data "aws_lb" "alb" {
-  arn  = "${data.aws_lb_listener.alb.load_balancer_arn}"
+  count = "${var.create_dns_record ? 1 : 0}"
+  arn   = "${data.aws_lb_listener.alb.load_balancer_arn}"
 }
 
 resource "aws_route53_record" "teleport" {
+  count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
   name    = "teleport.${var.domain_name}"
   type    = "A"

--- a/teleport-ecs/iam.tf
+++ b/teleport-ecs/iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "teleport" {
+  name = "teleport-task-role"
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2008-10-17",
+ "Statement": [
+   {
+     "Sid": "",
+     "Effect": "Allow",
+     "Principal": {
+       "Service": "ecs-tasks.amazonaws.com"
+     },
+     "Action": "sts:AssumeRole"
+   }
+ ]
+}
+EOF
+}
+
+
+module "iam_policy" { 
+    source  = "../teleport-auth-iam-policy"
+    role_id = "${aws_iam_role.teleport.id}"  
+}

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,5 +1,5 @@
 module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.3"
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.4"
   name                      = "teleport-web"
   environment               = "${var.environment}"
   project                   = "${var.project}"
@@ -9,6 +9,7 @@ module "target" {
   listener_condition_field  = "host-header"
   listener_condition_values = ["teleport.${var.domain_name}"]
   target_port               = "3080"
+  target_protocol           = "HTTPS"
   target_health_path        = "/web"
 
   tags = {

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,0 +1,59 @@
+module "target" {
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.2"
+  name                      = "teleport-web"
+  environment               = "${var.environment}"
+  project                   = "${var.project}"
+  vpc_id                    = "${var.vpc_id}"
+  listener_arn              = "${var.alb_listener_arn}"
+  listener_priority         = 100
+  listener_condition_field  = "host-header"
+  listener_condition_values = ["teleport.${var.domain_name}"]
+  target_port               = "3080"
+  target_health_path        = "/web"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}
+
+module "nlb_cli" {
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  environment           = "${var.environment}"
+  project               = "${var.project}"
+  vpc_id                = "${var.vpc_id}"
+  name_prefix           = "cli"
+  nlb_arn               = "${var.nlb_arn}"
+  ingress_port          = "3023"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}
+
+module "nlb_tunnel" {
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  environment           = "${var.environment}"
+  project               = "${var.project}"
+  vpc_id                = "${var.vpc_id}"
+  name_prefix           = "cli"
+  nlb_arn               = "${var.nlb_arn}"
+  ingress_port          = "3024"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}
+
+module "nlb_node" {
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  environment           = "${var.environment}"
+  project               = "${var.project}"
+  vpc_id                = "${var.vpc_id}"
+  name_prefix           = "cli"
+  nlb_arn               = "${var.nlb_private_arn}"
+  ingress_port          = "3025"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,5 +1,5 @@
 module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.4"
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.1.0"
   name                      = "teleport-web"
   environment               = "${var.environment}"
   project                   = "${var.project}"
@@ -46,7 +46,7 @@ module "nlb_tunnel" {
 }
 
 module "nlb_node" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.1.1"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -35,7 +35,7 @@ module "nlb_tunnel" {
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
-  name_prefix           = "cli"
+  name_prefix           = "tunnel"
   nlb_arn               = "${var.nlb_arn}"
   ingress_port          = "3024"
 
@@ -49,7 +49,7 @@ module "nlb_node" {
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
-  name_prefix           = "cli"
+  name_prefix           = "node"
   nlb_arn               = "${var.nlb_private_arn}"
   ingress_port          = "3025"
 

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,5 +1,5 @@
 module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.2"
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.3"
   name                      = "teleport-web"
   environment               = "${var.environment}"
   project                   = "${var.project}"
@@ -17,7 +17,7 @@ module "target" {
 }
 
 module "nlb_cli" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
@@ -31,7 +31,7 @@ module "nlb_cli" {
 }
 
 module "nlb_tunnel" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
@@ -45,7 +45,7 @@ module "nlb_tunnel" {
 }
 
 module "nlb_node" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"

--- a/teleport-ecs/main.tf
+++ b/teleport-ecs/main.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "teleport" {
+  name              = "teleport_logs"
+  retention_in_days = "7"
+
+  tags {
+    Environment = "${var.environment}"
+  }
+}

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -8,15 +8,21 @@
     "environment": [
         { "name": "ENABLE_AUTH", "value": "yes" },
         { "name": "ENABLE_PROXY", "value": "no" },
+        { "name": "ENABLE_NODE", "value": "yes" },
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
         { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
         { "name": "TOKENS", "value": "${tokens}" },
         { "name": "LOG_SEVERITY", "value": "INFO" }
     ],
-    "portMappings": [{
+    "portMappings": [
+      {
         "containerPort": 3025
-    }],
+      },
+      {
+        "containerPort": 3022
+      }
+    ],
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -1,0 +1,26 @@
+[{
+    "name": "teleport-auth",
+    "image": "skyscrapers/teleport:${teleport_version}",
+    "essential": true,
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "memoryReservation": ${memory_reservation},
+    "environment": [
+        { "name": "ENABLE_AUTH", "value": "yes" },
+        { "name": "ENABLE_PROXY", "value": "no" },
+        { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+        { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
+        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" }
+    ],
+    "portMappings": [{
+        "containerPort": 3025
+    }],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${log_group}",
+            "awslogs-region": "${aws_region}",
+            "awslogs-stream-prefix": "teleport-auth"
+        }
+    }
+}]

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -20,7 +20,8 @@
         "containerPort": 3025
       },
       {
-        "containerPort": 3022
+        "containerPort": 3022,
+        "hostPort": 3022
       }
     ],
     "logConfiguration": {
@@ -30,5 +31,10 @@
             "awslogs-region": "${aws_region}",
             "awslogs-stream-prefix": "teleport-auth"
         }
-    }
+    },
+    "placementConstraints": [
+      {
+        "type": "distinctInstance"
+      }
+    ]
 }]

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -10,7 +10,9 @@
         { "name": "ENABLE_PROXY", "value": "no" },
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
-        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" }
+        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
+        { "name": "TOKENS", "value": "${tokens}" },
+        { "name": "LOG_SEVERITY", "value": "INFO" }
     ],
     "portMappings": [{
         "containerPort": 3025

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -1,0 +1,28 @@
+[{
+    "name": "teleport-proxy",
+    "image": "skyscrapers/teleport:${teleport_version}",
+    "essential": true,
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "memoryReservation": ${memory_reservation},
+    "environment": [
+        { "name": "ENABLE_AUTH", "value": "no" },
+        { "name": "ENABLE_PROXY", "value": "yes" },
+        { "name": "AUTH_SERVERS", "value": "${auth_servers}" }
+    ],
+    "portMappings": [{
+        "containerPort": 3023
+    }, {
+        "containerPort": 3024
+    }, {
+        "containerPort": 3080
+    }],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${log_group}",
+            "awslogs-region": "${aws_region}",
+            "awslogs-stream-prefix": "teleport-proxy"
+        }
+    }
+}]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -11,7 +11,8 @@
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
         { "name": "AUTH_TOKEN", "value": "${auth_token}" },
-        { "name": "LOG_SEVERITY", "value": "INFO" }
+        { "name": "LOG_SEVERITY", "value": "INFO" },
+        { "name": "ADVERTISE_EC2_IP", "value": "no" }
     ],
     "portMappings": [{
         "containerPort": 3023

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -25,7 +25,7 @@
         "options": {
             "awslogs-group": "${log_group}",
             "awslogs-region": "${aws_region}",
-            "awslogs-stream-prefix": "teleport-proxy"
+            "awslogs-stream-prefix": "teleport-proxy-${function}"
         }
     }
 }]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -8,7 +8,10 @@
     "environment": [
         { "name": "ENABLE_AUTH", "value": "no" },
         { "name": "ENABLE_PROXY", "value": "yes" },
-        { "name": "AUTH_SERVERS", "value": "${auth_servers}" }
+        { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+        { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
+        { "name": "AUTH_TOKEN", "value": "${auth_token}" },
+        { "name": "LOG_SEVERITY", "value": "INFO" }
     ],
     "portMappings": [{
         "containerPort": 3023

--- a/teleport-ecs/teleport-auth.tf
+++ b/teleport-ecs/teleport-auth.tf
@@ -1,0 +1,46 @@
+resource "aws_ecs_task_definition" "teleport_auth" {
+  family                = "teleport"
+  container_definitions = "${data.template_file.teleport_auth.rendered}"
+  network_mode          = "bridge"
+  task_role_arn         = "${aws_iam_role.teleport.arn}"
+}
+
+
+data "template_file" "teleport_auth" {
+  template = "${file("${path.module}/task-definitions/teleport-auth.json")}"
+
+  vars {
+    cpu                = "${var.cpu}"
+    memory             = "${var.memory}"
+    memory_reservation = "${var.memory_reservation}"
+    aws_region         = "${var.aws_region}"
+    log_group          = "${aws_cloudwatch_log_group.teleport.id}"
+    teleport_version   = "${var.teleport_version}"
+    cluster_name       = "${var.cluster_name}"
+    dynamodb_table     = "${var.dynamodb_table}.auth"
+    dynamodb_region    = "${var.dynamodb_region}"
+  }
+}
+
+resource "aws_ecs_service" "teleport_auth" {
+  name            = "teleport-auth"
+  cluster         = "${var.ecs_cluster}"
+  task_definition = "${aws_ecs_task_definition.teleport_auth.arn}"
+  desired_count   = "${var.desired_count}"
+
+  load_balancer {
+    target_group_arn = "${module.nlb_node.target_group_arn}"
+    container_name   = "teleport-auth"
+    container_port   = "3025"
+  }
+  
+  placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+}

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -17,8 +17,10 @@ data "template_file" "teleport_proxy" {
     memory_reservation = "${var.memory_reservation}"
     aws_region         = "${var.aws_region}"
     log_group          = "${aws_cloudwatch_log_group.teleport.id}"
+    cluster_name       = "${var.cluster_name}"
     teleport_version   = "${var.teleport_version}"
     auth_servers       = "${data.aws_lb.nlb_node.dns_name}:3025"
+    auth_token         = "${random_string.proxy_token.result}"
   }
 }
 
@@ -41,7 +43,7 @@ resource "aws_ecs_service" "teleport_proxy" {
     container_name   = "teleport-proxy"
     container_port   = "${local.ports[count.index]}"
   }
-  
+
   placement_strategy {
     type  = "spread"
     field = "attribute:ecs.availability-zone"

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -1,0 +1,54 @@
+resource "aws_ecs_task_definition" "teleport_proxy" {
+  family                = "teleport-proxy"
+  container_definitions = "${data.template_file.teleport_proxy.rendered}"
+  network_mode          = "bridge"
+}
+
+data "aws_lb" "nlb_node" {
+  arn  = "${var.nlb_private_arn}"
+}
+
+data "template_file" "teleport_proxy" {
+  template = "${file("${path.module}/task-definitions/teleport-proxy.json")}"
+
+  vars {
+    cpu                = "${var.cpu}"
+    memory             = "${var.memory}"
+    memory_reservation = "${var.memory_reservation}"
+    aws_region         = "${var.aws_region}"
+    log_group          = "${aws_cloudwatch_log_group.teleport.id}"
+    teleport_version   = "${var.teleport_version}"
+    auth_servers       = "${data.aws_lb.nlb_node.dns_name}:3025"
+  }
+}
+
+locals {
+  ports = ["3023","3024","3080"]
+  functions = ["cli", "tunnel","web"]
+  targets = ["${module.nlb_cli.target_group_arn}","${module.nlb_tunnel.target_group_arn}","${module.target.target_group_arn}"]
+}
+
+
+resource "aws_ecs_service" "teleport_proxy" {
+  count           = 3
+  name            = "teleport-proxy-${local.functions[count.index]}"
+  cluster         = "${var.ecs_cluster}"
+  task_definition = "${aws_ecs_task_definition.teleport_proxy.arn}"
+  desired_count   = "${var.desired_count}"
+
+  load_balancer {
+    target_group_arn = "${local.targets[count.index]}"
+    container_name   = "teleport-proxy"
+    container_port   = "${local.ports[count.index]}"
+  }
+  
+  placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+}

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -15,12 +15,12 @@ variable "cpu" {
 
 variable "memory" {
   description = "The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
-  default     = "512"
+  default     = "128"
 }
 
 variable "memory_reservation" {
   description = "The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
-  default     = "254"
+  default     = "64"
 }
 
 variable "teleport_version" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -18,7 +18,7 @@ variable "memory_reservation" {
 }
 
 variable "teleport_version" {
-    default = "3.5.2"
+    default = "2.3.7"
 }
 
 variable "cluster_name" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -66,7 +66,7 @@ variable "alb_listener_arn" {
 }
 
 variable "nlb_arn" {
-  description = "ARN for the NLB to create a listener for CLI and tunnel of Tunnelport"
+  description = "ARN for the NLB to create a listener for CLI and tunnel"
 }
 
 variable "nlb_private_arn" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -18,7 +18,8 @@ variable "memory_reservation" {
 }
 
 variable "teleport_version" {
-  default = "2.3.7"
+  description = "Teleport version you want to install"
+  default     = "2.3.7"
 }
 
 variable "cluster_name" {
@@ -26,16 +27,19 @@ variable "cluster_name" {
 }
 
 variable "dynamodb_table" {
-  default = "main.teleport"
+  description = "Which dynamodb table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform"
+  default     = "main.teleport"
 }
 
 variable "dynamodb_region" {
-  default = "eu-west-1"
+  description = "In which region does the dynamodb table need to be created"
+  default     = "eu-west-1"
 }
 
 variable "tokens" {
-  type    = "list"
-  default = []
+  description = "List of tokens you want to add to the authentication server"
+  type        = "list"
+  default     = []
 }
 
 variable "environment" {
@@ -43,29 +47,35 @@ variable "environment" {
 }
 
 variable "vpc_id" {
-
+  description = "VPC ID of where we want to deploy Teleport in"
 }
 
 variable "domain_name" {
-
+  description = "Domain name of where we want to reach our cluster. Example can be `company.com`"
 }
 
 variable "alb_listener_arn" {
-
+  description = "ARN for the ALB listener, this will be used to add a rule to for the Teleport web part"
 }
 
 variable "nlb_arn" {
-
+  description = "ARN for the NLB to create a listener for CLI and tunnel of Tunnelport"
 }
 
 variable "nlb_private_arn" {
-
+  description = "ARN for the private NLB to create a listener for the Node auth containers"
 }
 
 variable "ecs_cluster" {
-
+  description = "Name of the ECS cluster"
 }
 
 variable "desired_count" {
-  default = 1
+  description = "Desired amount of containers we want to have running of each Teleport component"
+  default     = 1
+}
+
+variable "create_dns_record" {
+  description = "Create DNS records to reach teleport"
+  default     = "true"
 }

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -18,7 +18,7 @@ variable "memory_reservation" {
 }
 
 variable "teleport_version" {
-    default = "2.3.7"
+  default = "2.3.7"
 }
 
 variable "cluster_name" {
@@ -26,15 +26,16 @@ variable "cluster_name" {
 }
 
 variable "dynamodb_table" {
-    default = "main.teleport"
+  default = "main.teleport"
 }
 
 variable "dynamodb_region" {
-    default = "eu-west-1"
+  default = "eu-west-1"
 }
 
 variable "tokens" {
-
+  type    = "list"
+  default = []
 }
 
 variable "environment" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -1,0 +1,70 @@
+variable "aws_region" {
+  default = "eu-west-1"
+}
+
+variable "project" {
+}
+
+variable "cpu" {
+  default = "512"
+}
+
+variable "memory" {
+  default = "1024"
+}
+
+variable "memory_reservation" {
+  default = "512"
+}
+
+variable "teleport_version" {
+    default = "3.5.2"
+}
+
+variable "cluster_name" {
+    
+}
+
+variable "dynamodb_table" {
+    default = "main.teleport"
+}
+
+variable "dynamodb_region" {
+    default = "eu-west-1"
+}
+
+variable "tokens" {
+    
+}
+
+variable "environment" {
+    
+}
+
+variable "vpc_id" {
+
+}
+
+variable "domain_name" {
+    
+}
+
+variable "alb_listener_arn" {
+    
+}
+
+variable "nlb_arn" {
+
+}
+
+variable "nlb_private_arn" {
+    
+}
+
+variable "ecs_cluster" {
+  
+} 
+
+variable "desired_count" {
+  default = 1
+}

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -6,15 +6,15 @@ variable "project" {
 }
 
 variable "cpu" {
-  default = "512"
+  default = "128"
 }
 
 variable "memory" {
-  default = "1024"
+  default = "512"
 }
 
 variable "memory_reservation" {
-  default = "512"
+  default = "254"
 }
 
 variable "teleport_version" {
@@ -22,7 +22,7 @@ variable "teleport_version" {
 }
 
 variable "cluster_name" {
-    
+
 }
 
 variable "dynamodb_table" {
@@ -34,11 +34,11 @@ variable "dynamodb_region" {
 }
 
 variable "tokens" {
-    
+
 }
 
 variable "environment" {
-    
+
 }
 
 variable "vpc_id" {
@@ -46,11 +46,11 @@ variable "vpc_id" {
 }
 
 variable "domain_name" {
-    
+
 }
 
 variable "alb_listener_arn" {
-    
+
 }
 
 variable "nlb_arn" {
@@ -58,12 +58,12 @@ variable "nlb_arn" {
 }
 
 variable "nlb_private_arn" {
-    
+
 }
 
 variable "ecs_cluster" {
-  
-} 
+
+}
 
 variable "desired_count" {
   default = 1

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -1,20 +1,26 @@
 variable "aws_region" {
+  description = "AWS region we are deploying in"
   default = "eu-west-1"
 }
 
 variable "project" {
+  description = "Project where this node belongs to, will be the second part of the node name. Defaults to ''"
+  default     = ""
 }
 
 variable "cpu" {
-  default = "128"
+  description = "The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered."
+  default     = "128"
 }
 
 variable "memory" {
-  default = "512"
+  description = "The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
+  default     = "512"
 }
 
 variable "memory_reservation" {
-  default = "254"
+  description = "The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
+  default     = "254"
 }
 
 variable "teleport_version" {
@@ -23,7 +29,7 @@ variable "teleport_version" {
 }
 
 variable "cluster_name" {
-
+  description = "Name of the cluster"
 }
 
 variable "dynamodb_table" {
@@ -43,7 +49,8 @@ variable "tokens" {
 }
 
 variable "environment" {
-
+  description = "Environment where this node belongs to, will be the third part of the node name. Defaults to ''"
+  default     = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
This module will deploy Teleport `auth` and `proxy` servers on an ECS cluster.
It will also create an ELB in front of `proxy`.