### PR TITLE
Run teleport on ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module "teleport_bootstrap_script" {
 }
 ```
 
-### teleport-ecs_cluster
+## teleport-ecs_cluster
 
 This module will deploy Teleport on ECS. This takes care of the auth and proxy components. All components are exposed through an public ALB (web), public NLB (tunnel/cli) and private NLB (node). An initial user is created so you can logon and start creating users.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ These are the different ports that Teleport exposes, and the LB that they are at
 - `proxy` port 3024: Used for other Teleport clusters to open a reverse tunnel (trusted clusters). Mapped to the same port in the public ELB.
 - `proxy` port 3080: Used to serve the Web UI. Mapped to port 443 in the public ELB.
 
+Audit logs generated in the `auth` server will be shipped to CloudWatch logs, it'll create a new log group named `"teleport_logs_${var.environment}_${var.project}"`.
+
 ### Available variables:
 * [`cluster_name`]: String(required): Name of the cluster.
 * [`domain_name`]: String(required): Domain name of where we want to reach our cluster. Example can be `company.com`

--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ Audit logs generated in the `auth` server will be shipped to CloudWatch logs, it
 * [`domain_name`]: String(required): Domain name of where we want to reach our cluster. Example can be `company.com`
 * [`nlb_private_arn`]: String(required): ARN for the private NLB to create a listener for the Node `auth` containers
 * [`vpc_id`]: String(required): VPC ID of where we want to deploy Teleport in
-* [`aws_region`]: String(optional): AWS region where the CloudWatch logs are located. Defaults to eu-west-1
+* [`aws_region`]: String(optional): AWS region where the CloudWatch logs are going to be shipped, and where the DynamoDB table is going to be created. Defaults to eu-west-1
 * [`cpu`]: Integer(optional): The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered. Defaults to 128.
 * [`dynamodb_table`]: String(optional): Which DynamoDB table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform. Defaults to main.teleport
-* [`dynamodb_region`]: String(optional): In which region does the DynamoDB table need to be created. Defaults to eu-west-1
 * [`environment`]: String(optional): Environment where this node belongs to, will be the third part of the node name. Defaults to ''
 * [`memory`]: Integer(optional): The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered. Defaults to 128
 * [`memory_reservation`]: Integer(optional): The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Defaults to 64

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Terraform module to provision Teleport related resources.
 
 ### Available variables:
 * [`role_id`]: String(required): IAM role ID where to attach the Teleport policy.
+* [`dynamodb_table`]: String(required): Name of the DynamoDB table.
+* [`dynamodb_region`]: String(optional): Region of the DynamoDB table. Defaults to `eu-west-1`
 
 ### Output
 -
@@ -12,8 +14,9 @@ Terraform module to provision Teleport related resources.
 ### Example
 ```
 module "teleport_iam_policy" {
-  source  = "github.com/skyscrapers/terraform-teleport//teleport-auth-iam-policy?ref=1.0.0"
-  role_id = "${module.tools.iam_role_id}"
+  source         = "github.com/skyscrapers/terraform-teleport//teleport-auth-iam-policy?ref=2.3.0"
+  role_id        = "${module.tools.iam_role_id}"
+  dynamodb_table = "main.teleport.auth"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,27 +79,43 @@ module "teleport_bootstrap_script" {
 }
 ```
 
-## teleport-ecs_cluster
+## teleport-ecs
 
-This module will deploy Teleport on ECS. This takes care of the auth and proxy components. All components are exposed through an public ALB (web), public NLB (tunnel/cli) and private NLB (node). An initial user is created so you can logon and start creating users.
+This module will deploy Teleport on ECS. This takes care of the `auth` and `proxy` components.
+
+These are the different ports that Teleport exposes, and the LB that they are attached to.
+
+- `auth` port 3025: Used by nodes to register with the cluster. Mapped to the same port in the private NLB (ARN provided by parameter to this module).
+- `proxy` port 3023: Used for clients to SSH into a node. Mapped to the same port in the public ELB.
+- `proxy` port 3024: Used for other Teleport clusters to open a reverse tunnel (trusted clusters). Mapped to the same port in the public ELB.
+- `proxy` port 3080: Used to serve the Web UI. Mapped to port 443 in the public ELB.
 
 ### Available variables:
-* [`alb_listener_arn`]: String(required): ARN for the ALB listener, this will be used to add a rule to for the Teleport web part
 * [`cluster_name`]: String(required): Name of the cluster.
 * [`domain_name`]: String(required): Domain name of where we want to reach our cluster. Example can be `company.com`
-* [`nlb_arn`]: String(required): ARN for the NLB to create a listener for CLI and tunnel
-* [`nlb_private_arn`]: String(required): ARN for the private NLB to create a listener for the Node auth containers
+* [`nlb_private_arn`]: String(required): ARN for the private NLB to create a listener for the Node `auth` containers
 * [`vpc_id`]: String(required): VPC ID of where we want to deploy Teleport in
-* [`aws_region`]: String(optional): AWS region where the cloudwatch logs are located. Defaults to eu-west-1
+* [`aws_region`]: String(optional): AWS region where the CloudWatch logs are located. Defaults to eu-west-1
 * [`cpu`]: Integer(optional): The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered. Defaults to 128.
-* [`dynamodb_table`]: String(optional): Which dynamodb table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform. Defaults to main.teleport
-* [`dynamodb_region`]: String(optional): In which region does the dynamodb table need to be created. Defaults to eu-west-1
+* [`dynamodb_table`]: String(optional): Which DynamoDB table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform. Defaults to main.teleport
+* [`dynamodb_region`]: String(optional): In which region does the DynamoDB table need to be created. Defaults to eu-west-1
 * [`environment`]: String(optional): Environment where this node belongs to, will be the third part of the node name. Defaults to ''
-* [`memory`]: Integer(optional): The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered. Defaults to 512
-* [`memory_reservation`]: Integer(optional): The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Defaults to 254
+* [`memory`]: Integer(optional): The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered. Defaults to 128
+* [`memory_reservation`]: Integer(optional): The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Defaults to 64
 * [`project`]: String(optional): Project where this node belongs to, will be the second part of the node name. Defaults to ''
-* [`teleport_version`]: String(optional): Teleport version you want to install. Defaults to 2.3.7
+* [`teleport_version`]: String(optional): Teleport version you want to install. Defaults to 2.4.0
 * [`tokens`]: List(optional): List of tokens you want to add to the authentication server. Defaults to []
+* [`cw_logs_cpu`]: Integer(optional): The number of CPU units used by the CloudWatch logs task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered. Defaults to 128
+* [`cw_logs_memory`]: Integer(optional): The amount of memory (in MiB) used by the CloudWatch logs task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered. Defaults to 128
+* [`cw_logs_memory_reservation`]: Integer(optional): The soft limit (in MiB) of memory to reserve for the CloudWatch logs container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first. Defaults to 64
+* [`elb_subnets`]: List(required): Subnets where to deploy the Teleport ELB
+* [`web_ssl_certificate_arn`]: String(optional): ARN of the SSL certificate to use for the Teleport ELB
+* [`web_allowed_cidr_blocks`]: List(optional): CIDR blocks that are allowed to access the web interface of the proxy server. Defaults to `["0.0.0.0/0"]`
+* [`cli_allowed_cidr_blocks`]: List(optional): CIDR blocks that are allowed to access the cli interface of the proxy server. Defaults to `["0.0.0.0/0"]`
+* [`tunnel_allowed_cidr_blocks`]: List(optional): CIDR blocks that are allowed to access the reverse tunnel interface of the proxy server. Defaults to `["0.0.0.0/0"]`
+* [`ecs_instances_sg_id`]: String(required): Security group ID of the backend ECS instances running Teleport
+* [`teleport_log_severity`]: String(optional): Logging configuration for Teleport, possible severity values are `INFO`, `WARN` and `ERROR`. Defaults to `ERROR`
+* [`create_dns_record`]: String(optional): Create DNS records to reach teleport. Defaults to `"true"`
 
 ### Output
 /
@@ -107,19 +123,19 @@ This module will deploy Teleport on ECS. This takes care of the auth and proxy c
 ### Example
 ```
 module "teleport" {
-  source      = "github.com/skyscrapers/terraform-teleport//teleport-ecs?ref=2.3.0"
-  cluster_name     = "Skyscrapers-main"
-  tokens           = []
-  dynamodb_table   = "test.teleport"
-  environment      = "${terraform.workspace}"
-  vpc_id           = "${data.terraform_remote_state.static.vpc_id}"
-  domain_name      = "production.skyscrape.rs"
-  alb_listener_arn = "${data.terraform_remote_state.loadbalancers.app_https_listener_id}"
-  nlb_arn          = "${data.terraform_remote_state.loadbalancers.nlb_arn}"
-  nlb_private_arn  = "${data.terraform_remote_state.loadbalancers.nlb_private_arn}"
-  project          = "int"
-  ecs_cluster      = "${data.terraform_remote_state.ecs.ecs_cluster}"
-  create_dns_record = "false"
+  source                  = "github.com/skyscrapers/terraform-teleport//teleport-ecs?ref=2.3.0"
+  cluster_name            = "Skyscrapers-main"
+  tokens                  = ["trusted_cluster:changeme", "node:changemetoo"]
+  dynamodb_table          = "test.teleport.auth"
+  environment             = "${terraform.workspace}"
+  vpc_id                  = "${data.terraform_remote_state.static.vpc_id}"
+  domain_name             = "production.skyscrape.rs"
+  nlb_private_arn         = "${data.terraform_remote_state.loadbalancers.nlb_private_arn}"
+  project                 = "int"
+  ecs_cluster             = "${data.terraform_remote_state.ecs.ecs_cluster}"
+  create_dns_record       = "true"
+  ecs_instances_sg_id     = "${data.terraform_remote_state.ecs.sg_ecs_instance_id}"
+  web_ssl_certificate_arn = "arn:aws:acm:eu-west-1:1924395464:certificate/234523-235tert-243fdf"
+  elb_subnets             = "${data.terraform_remote_state.static.public_lb_subnets}"
 }
-
 ```

--- a/teleport-auth-iam-policy/main.tf
+++ b/teleport-auth-iam-policy/main.tf
@@ -1,32 +1,35 @@
 resource "aws_iam_role_policy" "policy" {
-  role = "${var.role_id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "AllAPIActionsOnTeleportAuth",
-      "Effect": "Allow",
-      "Action": "dynamodb:*",
-      "Resource": "arn:aws:dynamodb:*:*:table/*teleport.auth"
-    },
-    {
-      "Sid": "CloudWatchLogsAccess",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": [
-        "arn:aws:logs:*:*:log-group:teleport_audit_log",
-        "arn:aws:logs:*:*:log-group:teleport_audit_log:*"
-      ]
-    }
-  ]
+  role   = "${var.role_id}"
+  policy = "${data.aws_iam_policy_document.teleport.json}"
 }
-EOF
+
+data "aws_iam_policy_document" "teleport" {
+  statement {
+    sid = "AllAPIActionsOnTeleportAuth"
+
+    actions = [
+      "dynamodb:*",
+    ]
+
+    resources = [
+      "arn:aws:dynamodb:${var.dynamodb_region}:*:table/${var.dynamodb_table}",
+    ]
+  }
+
+  statement {
+    sid = "CloudWatchLogsAccess"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:log-group:teleport_audit_log",
+      "arn:aws:logs:*:*:log-group:teleport_audit_log:*",
+    ]
+  }
 }

--- a/teleport-auth-iam-policy/variables.tf
+++ b/teleport-auth-iam-policy/variables.tf
@@ -8,4 +8,5 @@ variable "dynamodb_table" {
 
 variable "dynamodb_region" {
   description = "Region of the DynamoDB table"
+  default     = "eu-west-1"
 }

--- a/teleport-auth-iam-policy/variables.tf
+++ b/teleport-auth-iam-policy/variables.tf
@@ -1,3 +1,11 @@
 variable "role_id" {
   description = "IAM role ID where to attach the Teleport policy."
 }
+
+variable "dynamodb_table" {
+  description = "Name of the DynamoDB table"
+}
+
+variable "dynamodb_region" {
+  description = "Region of the DynamoDB table"
+}

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -31,7 +31,7 @@ resource "aws_route53_record" "teleport" {
   }
 }
 
-resource "aws_route53_record" "teleport" {
+resource "aws_route53_record" "teleport_tsh" {
   count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
   name    = "tsh.${var.domain_name}"

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -3,21 +3,6 @@ data "aws_route53_zone" "teleport" {
   name  = "${var.domain_name}."
 }
 
-data "aws_lb_listener" "alb" {
-  count = "${var.create_dns_record ? 1 : 0}"
-  arn   = "${var.alb_listener_arn}"
-}
-
-data "aws_lb" "alb" {
-  count = "${var.create_dns_record ? 1 : 0}"
-  arn   = "${data.aws_lb_listener.alb.load_balancer_arn}"
-}
-
-data "aws_lb" "nlb" {
-  count = "${var.create_dns_record ? 1 : 0}"
-  arn   = "${var.nlb_arn}"
-}
-
 resource "aws_route53_record" "teleport" {
   count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
@@ -25,21 +10,8 @@ resource "aws_route53_record" "teleport" {
   type    = "A"
 
   alias {
-    name                   = "${data.aws_lb.alb.dns_name}"
-    zone_id                = "${data.aws_lb.alb.zone_id}"
-    evaluate_target_health = true
-  }
-}
-
-resource "aws_route53_record" "teleport_tsh" {
-  count   = "${var.create_dns_record ? 1 : 0}"
-  zone_id = "${data.aws_route53_zone.teleport.zone_id}"
-  name    = "tsh.${var.domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${data.aws_lb.nlb.dns_name}"
-    zone_id                = "${data.aws_lb.nlb.zone_id}"
+    name                   = "${aws_elb.proxy.dns_name}"
+    zone_id                = "${aws_elb.proxy.zone_id}"
     evaluate_target_health = true
   }
 }

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -13,6 +13,11 @@ data "aws_lb" "alb" {
   arn   = "${data.aws_lb_listener.alb.load_balancer_arn}"
 }
 
+data "aws_lb" "nlb" {
+  count = "${var.create_dns_record ? 1 : 0}"
+  arn   = "${var.nlb_arn}"
+}
+
 resource "aws_route53_record" "teleport" {
   count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
@@ -22,6 +27,19 @@ resource "aws_route53_record" "teleport" {
   alias {
     name                   = "${data.aws_lb.alb.dns_name}"
     zone_id                = "${data.aws_lb.alb.zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "teleport" {
+  count   = "${var.create_dns_record ? 1 : 0}"
+  zone_id = "${data.aws_route53_zone.teleport.zone_id}"
+  name    = "tsh.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_lb.nlb.dns_name}"
+    zone_id                = "${data.aws_lb.nlb.zone_id}"
     evaluate_target_health = true
   }
 }

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -1,0 +1,23 @@
+data "aws_route53_zone" "teleport" {
+  name         = "${var.domain_name}."
+}
+
+data "aws_lb_listener" "alb" {
+  arn = "${var.alb_listener_arn}"
+}
+
+data "aws_lb" "alb" {
+  arn  = "${data.aws_lb_listener.alb.load_balancer_arn}"
+}
+
+resource "aws_route53_record" "teleport" {
+  zone_id = "${data.aws_route53_zone.teleport.zone_id}"
+  name    = "teleport.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_lb.alb.dns_name}"
+    zone_id                = "${data.aws_lb.alb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/teleport-ecs/dns.tf
+++ b/teleport-ecs/dns.tf
@@ -1,16 +1,20 @@
 data "aws_route53_zone" "teleport" {
-  name         = "${var.domain_name}."
+  count = "${var.create_dns_record ? 1 : 0}"
+  name  = "${var.domain_name}."
 }
 
 data "aws_lb_listener" "alb" {
-  arn = "${var.alb_listener_arn}"
+  count = "${var.create_dns_record ? 1 : 0}"
+  arn   = "${var.alb_listener_arn}"
 }
 
 data "aws_lb" "alb" {
-  arn  = "${data.aws_lb_listener.alb.load_balancer_arn}"
+  count = "${var.create_dns_record ? 1 : 0}"
+  arn   = "${data.aws_lb_listener.alb.load_balancer_arn}"
 }
 
 resource "aws_route53_record" "teleport" {
+  count   = "${var.create_dns_record ? 1 : 0}"
   zone_id = "${data.aws_route53_zone.teleport.zone_id}"
   name    = "teleport.${var.domain_name}"
   type    = "A"

--- a/teleport-ecs/iam.tf
+++ b/teleport-ecs/iam.tf
@@ -22,5 +22,5 @@ module "iam_policy" {
   source          = "../teleport-auth-iam-policy"
   role_id         = "${aws_iam_role.teleport.id}"
   dynamodb_table  = "${var.dynamodb_table}"
-  dynamodb_region = "${var.dynamodb_region}"
+  dynamodb_region = "${var.aws_region}"
 }

--- a/teleport-ecs/iam.tf
+++ b/teleport-ecs/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "teleport" {
-  name = "teleport-task-role"
+  name_prefix = "teleport-task-${var.project}-"
 
   assume_role_policy = <<EOF
 {

--- a/teleport-ecs/iam.tf
+++ b/teleport-ecs/iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "teleport" {
+  name = "teleport-task-role"
+
+  assume_role_policy = <<EOF
+{
+ "Version": "2008-10-17",
+ "Statement": [
+   {
+     "Sid": "",
+     "Effect": "Allow",
+     "Principal": {
+       "Service": "ecs-tasks.amazonaws.com"
+     },
+     "Action": "sts:AssumeRole"
+   }
+ ]
+}
+EOF
+}
+
+
+module "iam_policy" { 
+    source  = "../teleport-auth-iam-policy"
+    role_id = "${aws_iam_role.teleport.id}"  
+}

--- a/teleport-ecs/iam.tf
+++ b/teleport-ecs/iam.tf
@@ -18,8 +18,9 @@ resource "aws_iam_role" "teleport" {
 EOF
 }
 
-
 module "iam_policy" {
-  source  = "../teleport-auth-iam-policy"
-  role_id = "${aws_iam_role.teleport.id}"  
+  source          = "../teleport-auth-iam-policy"
+  role_id         = "${aws_iam_role.teleport.id}"
+  dynamodb_table  = "${var.dynamodb_table}"
+  dynamodb_region = "${var.dynamodb_region}"
 }

--- a/teleport-ecs/iam.tf
+++ b/teleport-ecs/iam.tf
@@ -19,7 +19,7 @@ EOF
 }
 
 
-module "iam_policy" { 
-    source  = "../teleport-auth-iam-policy"
-    role_id = "${aws_iam_role.teleport.id}"  
+module "iam_policy" {
+  source  = "../teleport-auth-iam-policy"
+  role_id = "${aws_iam_role.teleport.id}"  
 }

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,60 +1,119 @@
-module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.1.0"
-  name                      = "teleport-web"
-  environment               = "${var.environment}"
-  project                   = "${var.project}"
-  vpc_id                    = "${var.vpc_id}"
-  listener_arn              = "${var.alb_listener_arn}"
-  listener_priority         = 100
-  listener_condition_field  = "host-header"
-  listener_condition_values = ["teleport.${var.domain_name}"]
-  target_port               = "3080"
-  target_protocol           = "HTTPS"
-  target_health_path        = "/web"
-
-  tags = {
-    Role = "loadbalancer"
-  }
-}
-
-module "nlb_cli" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
-  environment           = "${var.environment}"
-  project               = "${var.project}"
-  vpc_id                = "${var.vpc_id}"
-  name_prefix           = "cli"
-  nlb_arn               = "${var.nlb_arn}"
-  ingress_port          = "3023"
-
-  tags = {
-    Role = "loadbalancer"
-  }
-}
-
-module "nlb_tunnel" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
-  environment           = "${var.environment}"
-  project               = "${var.project}"
-  vpc_id                = "${var.vpc_id}"
-  name_prefix           = "tunnel"
-  nlb_arn               = "${var.nlb_arn}"
-  ingress_port          = "3024"
-
-  tags = {
-    Role = "loadbalancer"
-  }
-}
-
-module "nlb_node" {
+module "nlb_auth" {
   source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.1.1"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
-  name_prefix           = "node"
+  name_prefix           = "auth"
   nlb_arn               = "${var.nlb_private_arn}"
   ingress_port          = "3025"
 
   tags = {
     Role = "loadbalancer"
   }
+}
+
+resource "aws_elb" "proxy" {
+  name                        = "teleport-proxy-${var.project}-${var.environment}"
+  subnets                     = ["${var.elb_subnets}"]
+  internal                    = "false"
+  cross_zone_load_balancing   = true
+  idle_timeout                = "60"
+  connection_draining         = "true"
+  connection_draining_timeout = "60"
+  security_groups             = ["${aws_security_group.elb.id}"]
+
+  listener {
+    instance_port     = "3023"
+    instance_protocol = "tcp"
+    lb_port           = "3023"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "3024"
+    instance_protocol = "tcp"
+    lb_port           = "3024"
+    lb_protocol       = "tcp"
+  }
+
+  listener {
+    instance_port     = "3080"
+    instance_protocol = "https"
+    lb_port           = "443"
+    lb_protocol       = "https"
+    ssl_certificate_id = "${var.web_ssl_certificate_arn}"
+  }
+
+  health_check {
+    healthy_threshold   = "3"
+    unhealthy_threshold = "2"
+    timeout             = "10"
+    target              = "HTTPS:3080/webapi/ping"
+    interval            = "30"
+  }
+
+  tags {
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+  }
+}
+
+resource "aws_security_group" "elb" {
+  name_prefix = "teleport-proxy-elb-${var.project}-${var.environment}-"
+  description = "Security group for Teleport proxy on ${var.environment} for ${var.project}"
+  vpc_id      = "${var.vpc_id}"
+}
+
+resource "aws_security_group_rule" "web_from_world" {
+  security_group_id = "${aws_security_group.elb.id}"
+  type              = "ingress"
+  from_port         = "443"
+  to_port           = "443"
+  protocol          = "tcp"
+  cidr_blocks       = "${var.web_allowed_cidr_blocks}"
+}
+
+resource "aws_security_group_rule" "cli_from_world" {
+  security_group_id = "${aws_security_group.elb.id}"
+  type              = "ingress"
+  from_port         = "3023"
+  to_port           = "3023"
+  protocol          = "tcp"
+  cidr_blocks       = "${var.cli_allowed_cidr_blocks}"
+}
+
+resource "aws_security_group_rule" "tunnel_from_world" {
+  security_group_id = "${aws_security_group.elb.id}"
+  type              = "ingress"
+  from_port         = "3024"
+  to_port           = "3024"
+  protocol          = "tcp"
+  cidr_blocks       = "${var.tunnel_allowed_cidr_blocks}"
+}
+
+resource "aws_security_group_rule" "web_to_instances" {
+  security_group_id        = "${aws_security_group.elb.id}"
+  type                     = "egress"
+  from_port                = "3080"
+  to_port                  = "3080"
+  protocol                 = "tcp"
+  source_security_group_id = "${var.ecs_instances_sg_id}"
+}
+
+resource "aws_security_group_rule" "cli_to_instances" {
+  security_group_id        = "${aws_security_group.elb.id}"
+  type                     = "egress"
+  from_port                = "3023"
+  to_port                  = "3023"
+  protocol                 = "tcp"
+  source_security_group_id = "${var.ecs_instances_sg_id}"
+}
+
+resource "aws_security_group_rule" "tunnel_to_instances" {
+  security_group_id        = "${aws_security_group.elb.id}"
+  type                     = "egress"
+  from_port                = "3024"
+  to_port                  = "3024"
+  protocol                 = "tcp"
+  source_security_group_id = "${var.ecs_instances_sg_id}"
 }

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,5 +1,5 @@
 module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.3"
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.4"
   name                      = "teleport-web"
   environment               = "${var.environment}"
   project                   = "${var.project}"
@@ -9,6 +9,7 @@ module "target" {
   listener_condition_field  = "host-header"
   listener_condition_values = ["teleport.${var.domain_name}"]
   target_port               = "3080"
+  target_protocol           = "HTTPS"
   target_health_path        = "/web"
 
   tags = {

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,0 +1,59 @@
+module "target" {
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.2"
+  name                      = "teleport-web"
+  environment               = "${var.environment}"
+  project                   = "${var.project}"
+  vpc_id                    = "${var.vpc_id}"
+  listener_arn              = "${var.alb_listener_arn}"
+  listener_priority         = 100
+  listener_condition_field  = "host-header"
+  listener_condition_values = ["teleport.${var.domain_name}"]
+  target_port               = "3080"
+  target_health_path        = "/web"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}
+
+module "nlb_cli" {
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  environment           = "${var.environment}"
+  project               = "${var.project}"
+  vpc_id                = "${var.vpc_id}"
+  name_prefix           = "cli"
+  nlb_arn               = "${var.nlb_arn}"
+  ingress_port          = "3023"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}
+
+module "nlb_tunnel" {
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  environment           = "${var.environment}"
+  project               = "${var.project}"
+  vpc_id                = "${var.vpc_id}"
+  name_prefix           = "cli"
+  nlb_arn               = "${var.nlb_arn}"
+  ingress_port          = "3024"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}
+
+module "nlb_node" {
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  environment           = "${var.environment}"
+  project               = "${var.project}"
+  vpc_id                = "${var.vpc_id}"
+  name_prefix           = "cli"
+  nlb_arn               = "${var.nlb_private_arn}"
+  ingress_port          = "3025"
+
+  tags = {
+    Role = "loadbalancer"
+  }
+}

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,5 +1,5 @@
 module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.4"
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.1.0"
   name                      = "teleport-web"
   environment               = "${var.environment}"
   project                   = "${var.project}"
@@ -46,7 +46,7 @@ module "nlb_tunnel" {
 }
 
 module "nlb_node" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.1.1"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -35,7 +35,7 @@ module "nlb_tunnel" {
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
-  name_prefix           = "cli"
+  name_prefix           = "tunnel"
   nlb_arn               = "${var.nlb_arn}"
   ingress_port          = "3024"
 
@@ -49,7 +49,7 @@ module "nlb_node" {
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
-  name_prefix           = "cli"
+  name_prefix           = "node"
   nlb_arn               = "${var.nlb_private_arn}"
   ingress_port          = "3025"
 

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -38,9 +38,9 @@ resource "aws_elb" "proxy" {
 
   listener {
     instance_port     = "3080"
-    instance_protocol = "https"
+    instance_protocol = "ssl"
     lb_port           = "443"
-    lb_protocol       = "https"
+    lb_protocol       = "ssl"
     ssl_certificate_id = "${var.web_ssl_certificate_arn}"
   }
 

--- a/teleport-ecs/lb.tf
+++ b/teleport-ecs/lb.tf
@@ -1,5 +1,5 @@
 module "target" {
-  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.2"
+  source                    = "github.com/skyscrapers/terraform-loadbalancers//alb_rule_target?ref=5.0.3"
   name                      = "teleport-web"
   environment               = "${var.environment}"
   project                   = "${var.project}"
@@ -17,7 +17,7 @@ module "target" {
 }
 
 module "nlb_cli" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
@@ -31,7 +31,7 @@ module "nlb_cli" {
 }
 
 module "nlb_tunnel" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"
@@ -45,7 +45,7 @@ module "nlb_tunnel" {
 }
 
 module "nlb_node" {
-  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.2"
+  source                = "github.com/skyscrapers/terraform-loadbalancers//nlb_listener?ref=5.0.3"
   environment           = "${var.environment}"
   project               = "${var.project}"
   vpc_id                = "${var.vpc_id}"

--- a/teleport-ecs/main.tf
+++ b/teleport-ecs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "teleport" {
-  name              = "teleport_logs"
+  name              = "teleport_logs_${var.environment}_${var.project}"
   retention_in_days = "7"
 
   tags {

--- a/teleport-ecs/main.tf
+++ b/teleport-ecs/main.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "teleport" {
+  name              = "teleport_logs"
+  retention_in_days = "7"
+
+  tags {
+    Environment = "${var.environment}"
+  }
+}

--- a/teleport-ecs/sg.tf
+++ b/teleport-ecs/sg.tf
@@ -1,0 +1,62 @@
+resource "aws_security_group_rule" "ecs_ingress_node" {
+  security_group_id        = "${var.ecs_instances_sg_id}"
+  type                     = "ingress"
+  from_port                = "3022"
+  to_port                  = "3022"
+  protocol                 = "tcp"
+  self                     = true
+}
+
+resource "aws_security_group_rule" "ecs_ingress_cli" {
+  security_group_id        = "${var.ecs_instances_sg_id}"
+  type                     = "ingress"
+  from_port                = "3023"
+  to_port                  = "3023"
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.elb.id}"
+}
+
+resource "aws_security_group_rule" "ecs_ingress_tunnel" {
+  security_group_id        = "${var.ecs_instances_sg_id}"
+  type                     = "ingress"
+  from_port                = "3024"
+  to_port                  = "3024"
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.elb.id}"
+}
+
+resource "aws_security_group_rule" "ecs_ingress_auth" {
+  security_group_id = "${var.ecs_instances_sg_id}"
+  type              = "ingress"
+  from_port         = "3025"
+  to_port           = "3025"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ecs_ingress_web" {
+  security_group_id        = "${var.ecs_instances_sg_id}"
+  type                     = "ingress"
+  from_port                = "3080"
+  to_port                  = "3080"
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.elb.id}"
+}
+
+resource "aws_security_group_rule" "ecs_egress_node" {
+  security_group_id = "${var.ecs_instances_sg_id}"
+  type              = "egress"
+  from_port         = "3022"
+  to_port           = "3022"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ecs_egress_auth" {
+  security_group_id = "${var.ecs_instances_sg_id}"
+  type              = "egress"
+  from_port         = "3025"
+  to_port           = "3025"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -1,4 +1,5 @@
-[{
+[
+  {
     "name": "teleport-auth",
     "image": "skyscrapers/teleport:${teleport_version}",
     "essential": true,
@@ -6,16 +7,16 @@
     "memory": ${memory},
     "memoryReservation": ${memory_reservation},
     "environment": [
-        { "name": "ENABLE_AUTH", "value": "yes" },
-        { "name": "ENABLE_PROXY", "value": "no" },
-        { "name": "ENABLE_NODE", "value": "yes" },
-        { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
-        { "name": "AUTH_SERVERS", "value": "127.0.0.1:3025" },
-        { "name": "AUTH_TOKEN", "value": "${auth_token}" },
-        { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
-        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
-        { "name": "TOKENS", "value": "${tokens}" },
-        { "name": "LOG_SEVERITY", "value": "${log_severity}" }
+      { "name": "ENABLE_AUTH", "value": "yes" },
+      { "name": "ENABLE_PROXY", "value": "no" },
+      { "name": "ENABLE_NODE", "value": "yes" },
+      { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+      { "name": "AUTH_SERVERS", "value": "127.0.0.1:3025" },
+      { "name": "AUTH_TOKEN", "value": "${auth_token}" },
+      { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
+      { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
+      { "name": "TOKENS", "value": "${tokens}" },
+      { "name": "LOG_SEVERITY", "value": "${log_severity}" }
     ],
     "portMappings": [
       {
@@ -28,16 +29,27 @@
       }
     ],
     "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${log_group}",
-            "awslogs-region": "${aws_region}",
-            "awslogs-stream-prefix": "teleport-auth"
-        }
-    },
-    "placementConstraints": [
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "teleport-auth"
+      }
+    }
+  },
+  {
+    "name": "cloudwatch-logs",
+    "image": "skyscrapers/cloudwatch-logs",
+    "command": ["/var/lib/teleport/log/*.log:teleport_audit_log"],
+    "essential": true,
+    "cpu": ${cw_logs_cpu},
+    "memory": ${cw_logs_memory},
+    "memoryReservation": ${cw_logs_memory_reservation},
+    "volumesFrom": [
       {
-        "type": "distinctInstance"
+        "SourceContainer": "teleport-auth",
+        "ReadOnly": true
       }
     ]
-}]
+  }
+]

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -8,15 +8,21 @@
     "environment": [
         { "name": "ENABLE_AUTH", "value": "yes" },
         { "name": "ENABLE_PROXY", "value": "no" },
+        { "name": "ENABLE_NODE", "value": "yes" },
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
         { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
         { "name": "TOKENS", "value": "${tokens}" },
         { "name": "LOG_SEVERITY", "value": "INFO" }
     ],
-    "portMappings": [{
+    "portMappings": [
+      {
         "containerPort": 3025
-    }],
+      },
+      {
+        "containerPort": 3022
+      }
+    ],
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -1,0 +1,26 @@
+[{
+    "name": "teleport-auth",
+    "image": "skyscrapers/teleport:${teleport_version}",
+    "essential": true,
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "memoryReservation": ${memory_reservation},
+    "environment": [
+        { "name": "ENABLE_AUTH", "value": "yes" },
+        { "name": "ENABLE_PROXY", "value": "no" },
+        { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+        { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
+        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" }
+    ],
+    "portMappings": [{
+        "containerPort": 3025
+    }],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${log_group}",
+            "awslogs-region": "${aws_region}",
+            "awslogs-stream-prefix": "teleport-auth"
+        }
+    }
+}]

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -20,7 +20,8 @@
         "containerPort": 3025
       },
       {
-        "containerPort": 3022
+        "containerPort": 3022,
+        "hostPort": 3022
       }
     ],
     "logConfiguration": {
@@ -30,5 +31,10 @@
             "awslogs-region": "${aws_region}",
             "awslogs-stream-prefix": "teleport-auth"
         }
-    }
+    },
+    "placementConstraints": [
+      {
+        "type": "distinctInstance"
+      }
+    ]
 }]

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -10,6 +10,8 @@
         { "name": "ENABLE_PROXY", "value": "no" },
         { "name": "ENABLE_NODE", "value": "yes" },
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+        { "name": "AUTH_SERVERS", "value": "127.0.0.1:3025" },
+        { "name": "AUTH_TOKEN", "value": "${auth_token}" },
         { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
         { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
         { "name": "TOKENS", "value": "${tokens}" },

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -9,23 +9,19 @@
     "environment": [
       { "name": "ENABLE_AUTH", "value": "yes" },
       { "name": "ENABLE_PROXY", "value": "no" },
-      { "name": "ENABLE_NODE", "value": "yes" },
+      { "name": "ENABLE_NODE", "value": "no" },
       { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
-      { "name": "AUTH_SERVERS", "value": "127.0.0.1:3025" },
-      { "name": "AUTH_TOKEN", "value": "${auth_token}" },
       { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
       { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
       { "name": "TOKENS", "value": "${tokens}" },
-      { "name": "LOG_SEVERITY", "value": "${log_severity}" }
+      { "name": "LOG_SEVERITY", "value": "${log_severity}" },
+      { "name": "CREATE_ADMIN_USER", "value": "no" },
+      { "name": "ADVERTISE_EC2_IP", "value": "no" }
     ],
     "portMappings": [
       {
         "containerPort": 3025,
         "hostPort": 3025
-      },
-      {
-        "containerPort": 3022,
-        "hostPort": 3022
       }
     ],
     "logConfiguration": {

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -10,7 +10,9 @@
         { "name": "ENABLE_PROXY", "value": "no" },
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
-        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" }
+        { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
+        { "name": "TOKENS", "value": "${tokens}" },
+        { "name": "LOG_SEVERITY", "value": "INFO" }
     ],
     "portMappings": [{
         "containerPort": 3025

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -15,7 +15,7 @@
         { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
         { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
         { "name": "TOKENS", "value": "${tokens}" },
-        { "name": "LOG_SEVERITY", "value": "INFO" }
+        { "name": "LOG_SEVERITY", "value": "${log_severity}" }
     ],
     "portMappings": [
       {

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -19,7 +19,8 @@
     ],
     "portMappings": [
       {
-        "containerPort": 3025
+        "containerPort": 3025,
+        "hostPort": 3025
       },
       {
         "containerPort": 3022,

--- a/teleport-ecs/task-definitions/teleport-auth.json
+++ b/teleport-ecs/task-definitions/teleport-auth.json
@@ -12,7 +12,7 @@
       { "name": "ENABLE_NODE", "value": "no" },
       { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
       { "name": "DYNAMODB_TABLE", "value": "${dynamodb_table}" },
-      { "name": "DYNAMODB_REGION", "value": "${dynamodb_region}" },
+      { "name": "DYNAMODB_REGION", "value": "${aws_region}" },
       { "name": "TOKENS", "value": "${tokens}" },
       { "name": "LOG_SEVERITY", "value": "${log_severity}" },
       { "name": "CREATE_ADMIN_USER", "value": "no" },

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -8,25 +8,33 @@
     "environment": [
         { "name": "ENABLE_AUTH", "value": "no" },
         { "name": "ENABLE_PROXY", "value": "yes" },
+        { "name": "ENABLE_NODE", "value": "no" },
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
         { "name": "AUTH_TOKEN", "value": "${auth_token}" },
         { "name": "LOG_SEVERITY", "value": "INFO" },
         { "name": "ADVERTISE_EC2_IP", "value": "no" }
     ],
-    "portMappings": [{
-        "containerPort": 3023
-    }, {
-        "containerPort": 3024
-    }, {
-        "containerPort": 3080
-    }],
+    "portMappings": [
+      {
+        "containerPort": 3023,
+        "hostPort": 3023
+      },
+      {
+        "containerPort": 3024,
+        "hostPort": 3024
+      },
+      {
+        "containerPort": 3080,
+        "hostPort": 3080
+      }
+    ],
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
             "awslogs-group": "${log_group}",
             "awslogs-region": "${aws_region}",
-            "awslogs-stream-prefix": "teleport-proxy-${function}"
+            "awslogs-stream-prefix": "teleport-proxy"
         }
     }
 }]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -6,14 +6,14 @@
     "memory": ${memory},
     "memoryReservation": ${memory_reservation},
     "environment": [
-        { "name": "ENABLE_AUTH", "value": "no" },
-        { "name": "ENABLE_PROXY", "value": "yes" },
-        { "name": "ENABLE_NODE", "value": "no" },
-        { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
-        { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
-        { "name": "AUTH_TOKEN", "value": "${auth_token}" },
-        { "name": "LOG_SEVERITY", "value": "${log_severity}" },
-        { "name": "ADVERTISE_EC2_IP", "value": "no" }
+      { "name": "ENABLE_AUTH", "value": "no" },
+      { "name": "ENABLE_PROXY", "value": "yes" },
+      { "name": "ENABLE_NODE", "value": "no" },
+      { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+      { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
+      { "name": "AUTH_TOKEN", "value": "${auth_token}" },
+      { "name": "LOG_SEVERITY", "value": "${log_severity}" },
+      { "name": "ADVERTISE_EC2_IP", "value": "no" }
     ],
     "portMappings": [
       {
@@ -30,16 +30,11 @@
       }
     ],
     "logConfiguration": {
-        "logDriver": "awslogs",
-        "options": {
-            "awslogs-group": "${log_group}",
-            "awslogs-region": "${aws_region}",
-            "awslogs-stream-prefix": "teleport-proxy"
-        }
-    },
-    "placementConstraints": [
-      {
-        "type": "distinctInstance"
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "teleport-proxy"
       }
-    ]
+    }
 }]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -36,5 +36,10 @@
             "awslogs-region": "${aws_region}",
             "awslogs-stream-prefix": "teleport-proxy"
         }
-    }
+    },
+    "placementConstraints": [
+      {
+        "type": "distinctInstance"
+      }
+    ]
 }]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -12,7 +12,7 @@
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
         { "name": "AUTH_TOKEN", "value": "${auth_token}" },
-        { "name": "LOG_SEVERITY", "value": "INFO" },
+        { "name": "LOG_SEVERITY", "value": "${log_severity}" },
         { "name": "ADVERTISE_EC2_IP", "value": "no" }
     ],
     "portMappings": [

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -1,0 +1,28 @@
+[{
+    "name": "teleport-proxy",
+    "image": "skyscrapers/teleport:${teleport_version}",
+    "essential": true,
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "memoryReservation": ${memory_reservation},
+    "environment": [
+        { "name": "ENABLE_AUTH", "value": "no" },
+        { "name": "ENABLE_PROXY", "value": "yes" },
+        { "name": "AUTH_SERVERS", "value": "${auth_servers}" }
+    ],
+    "portMappings": [{
+        "containerPort": 3023
+    }, {
+        "containerPort": 3024
+    }, {
+        "containerPort": 3080
+    }],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${log_group}",
+            "awslogs-region": "${aws_region}",
+            "awslogs-stream-prefix": "teleport-proxy"
+        }
+    }
+}]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -11,7 +11,8 @@
         { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
         { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
         { "name": "AUTH_TOKEN", "value": "${auth_token}" },
-        { "name": "LOG_SEVERITY", "value": "INFO" }
+        { "name": "LOG_SEVERITY", "value": "INFO" },
+        { "name": "ADVERTISE_EC2_IP", "value": "no" }
     ],
     "portMappings": [{
         "containerPort": 3023

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -25,7 +25,7 @@
         "options": {
             "awslogs-group": "${log_group}",
             "awslogs-region": "${aws_region}",
-            "awslogs-stream-prefix": "teleport-proxy"
+            "awslogs-stream-prefix": "teleport-proxy-${function}"
         }
     }
 }]

--- a/teleport-ecs/task-definitions/teleport-proxy.json
+++ b/teleport-ecs/task-definitions/teleport-proxy.json
@@ -8,7 +8,10 @@
     "environment": [
         { "name": "ENABLE_AUTH", "value": "no" },
         { "name": "ENABLE_PROXY", "value": "yes" },
-        { "name": "AUTH_SERVERS", "value": "${auth_servers}" }
+        { "name": "CLUSTER_NAME", "value": "${cluster_name}" },
+        { "name": "AUTH_SERVERS", "value": "${auth_servers}" },
+        { "name": "AUTH_TOKEN", "value": "${auth_token}" },
+        { "name": "LOG_SEVERITY", "value": "INFO" }
     ],
     "portMappings": [{
         "containerPort": 3023

--- a/teleport-ecs/teleport-auth.tf
+++ b/teleport-ecs/teleport-auth.tf
@@ -24,7 +24,7 @@ data "template_file" "teleport_auth" {
     log_group                  = "${aws_cloudwatch_log_group.teleport.id}"
     teleport_version           = "${var.teleport_version}"
     cluster_name               = "${var.cluster_name}"
-    dynamodb_table             = "${var.dynamodb_table}.auth"
+    dynamodb_table             = "${var.dynamodb_table}"
     dynamodb_region            = "${var.dynamodb_region}"
     auth_token                 = "${random_string.proxy_token.result}"
     tokens                     = "${join(" ", concat(var.tokens, list("proxy,node:${random_string.proxy_token.result}")))}"

--- a/teleport-ecs/teleport-auth.tf
+++ b/teleport-ecs/teleport-auth.tf
@@ -25,6 +25,7 @@ data "template_file" "teleport_auth" {
     dynamodb_region    = "${var.dynamodb_region}"
     auth_token         = "${random_string.proxy_token.result}"
     tokens             = "${join(" ", concat(var.tokens, list("proxy,node:${random_string.proxy_token.result}")))}"
+    log_severity       = "${var.teleport_log_severity}"
   }
 }
 

--- a/teleport-ecs/teleport-auth.tf
+++ b/teleport-ecs/teleport-auth.tf
@@ -25,7 +25,6 @@ data "template_file" "teleport_auth" {
     teleport_version           = "${var.teleport_version}"
     cluster_name               = "${var.cluster_name}"
     dynamodb_table             = "${var.dynamodb_table}"
-    dynamodb_region            = "${var.dynamodb_region}"
     auth_token                 = "${random_string.proxy_token.result}"
     tokens                     = "${join(" ", concat(var.tokens, list("proxy,node:${random_string.proxy_token.result}")))}"
     log_severity               = "${var.teleport_log_severity}"

--- a/teleport-ecs/teleport-auth.tf
+++ b/teleport-ecs/teleport-auth.tf
@@ -1,0 +1,46 @@
+resource "aws_ecs_task_definition" "teleport_auth" {
+  family                = "teleport"
+  container_definitions = "${data.template_file.teleport_auth.rendered}"
+  network_mode          = "bridge"
+  task_role_arn         = "${aws_iam_role.teleport.arn}"
+}
+
+
+data "template_file" "teleport_auth" {
+  template = "${file("${path.module}/task-definitions/teleport-auth.json")}"
+
+  vars {
+    cpu                = "${var.cpu}"
+    memory             = "${var.memory}"
+    memory_reservation = "${var.memory_reservation}"
+    aws_region         = "${var.aws_region}"
+    log_group          = "${aws_cloudwatch_log_group.teleport.id}"
+    teleport_version   = "${var.teleport_version}"
+    cluster_name       = "${var.cluster_name}"
+    dynamodb_table     = "${var.dynamodb_table}.auth"
+    dynamodb_region    = "${var.dynamodb_region}"
+  }
+}
+
+resource "aws_ecs_service" "teleport_auth" {
+  name            = "teleport-auth"
+  cluster         = "${var.ecs_cluster}"
+  task_definition = "${aws_ecs_task_definition.teleport_auth.arn}"
+  desired_count   = "${var.desired_count}"
+
+  load_balancer {
+    target_group_arn = "${module.nlb_node.target_group_arn}"
+    container_name   = "teleport-auth"
+    container_port   = "3025"
+  }
+  
+  placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+}

--- a/teleport-ecs/teleport-auth.tf
+++ b/teleport-ecs/teleport-auth.tf
@@ -14,18 +14,21 @@ data "template_file" "teleport_auth" {
   template = "${file("${path.module}/task-definitions/teleport-auth.json")}"
 
   vars {
-    cpu                = "${var.cpu}"
-    memory             = "${var.memory}"
-    memory_reservation = "${var.memory_reservation}"
-    aws_region         = "${var.aws_region}"
-    log_group          = "${aws_cloudwatch_log_group.teleport.id}"
-    teleport_version   = "${var.teleport_version}"
-    cluster_name       = "${var.cluster_name}"
-    dynamodb_table     = "${var.dynamodb_table}.auth"
-    dynamodb_region    = "${var.dynamodb_region}"
-    auth_token         = "${random_string.proxy_token.result}"
-    tokens             = "${join(" ", concat(var.tokens, list("proxy,node:${random_string.proxy_token.result}")))}"
-    log_severity       = "${var.teleport_log_severity}"
+    cpu                        = "${var.cpu}"
+    memory                     = "${var.memory}"
+    memory_reservation         = "${var.memory_reservation}"
+    cw_logs_cpu                = "${var.cw_logs_cpu}"
+    cw_logs_memory             = "${var.cw_logs_memory}"
+    cw_logs_memory_reservation = "${var.cw_logs_memory_reservation}"
+    aws_region                 = "${var.aws_region}"
+    log_group                  = "${aws_cloudwatch_log_group.teleport.id}"
+    teleport_version           = "${var.teleport_version}"
+    cluster_name               = "${var.cluster_name}"
+    dynamodb_table             = "${var.dynamodb_table}.auth"
+    dynamodb_region            = "${var.dynamodb_region}"
+    auth_token                 = "${random_string.proxy_token.result}"
+    tokens                     = "${join(" ", concat(var.tokens, list("proxy,node:${random_string.proxy_token.result}")))}"
+    log_severity               = "${var.teleport_log_severity}"
   }
 }
 
@@ -49,5 +52,9 @@ resource "aws_ecs_service" "teleport_auth" {
   placement_strategy {
     type  = "spread"
     field = "instanceId"
+  }
+
+  placement_constraints {
+    type = "distinctInstance"
   }
 }

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -1,7 +1,6 @@
 resource "aws_ecs_task_definition" "teleport_proxy" {
-  count                 = 3
-  family                = "teleport-proxy-${local.functions[count.index]}"
-  container_definitions = "${data.template_file.teleport_proxy.*.rendered[count.index]}"
+  family                = "teleport-proxy"
+  container_definitions = "${data.template_file.teleport_proxy.rendered}"
   network_mode          = "bridge"
 }
 
@@ -10,7 +9,6 @@ data "aws_lb" "nlb_node" {
 }
 
 data "template_file" "teleport_proxy" {
-  count    = 3
   template = "${file("${path.module}/task-definitions/teleport-proxy.json")}"
 
   vars {
@@ -23,37 +21,18 @@ data "template_file" "teleport_proxy" {
     teleport_version   = "${var.teleport_version}"
     auth_servers       = "${data.aws_lb.nlb_node.dns_name}:3025"
     auth_token         = "${random_string.proxy_token.result}"
-    function           = "${local.functions[count.index]}"
   }
 }
-
-locals {
-  ports = ["3023","3024","3080"]
-  functions = ["cli", "tunnel","web"]
-  targets = ["${module.nlb_cli.target_group_arn}","${module.nlb_tunnel.target_group_arn}","${module.target.target_group_arn}"]
-}
-
 
 resource "aws_ecs_service" "teleport_proxy" {
-  count           = 3
-  name            = "teleport-proxy-${local.functions[count.index]}"
+  name            = "teleport-proxy"
   cluster         = "${var.ecs_cluster}"
-  task_definition = "${aws_ecs_task_definition.teleport_proxy.*.arn[count.index]}"
-  desired_count   = "${var.desired_count}"
+  task_definition = "${aws_ecs_task_definition.teleport_proxy.arn}"
+  desired_count   = "1"
 
   load_balancer {
-    target_group_arn = "${local.targets[count.index]}"
-    container_name   = "teleport-proxy"
-    container_port   = "${local.ports[count.index]}"
-  }
-
-  placement_strategy {
-    type  = "spread"
-    field = "attribute:ecs.availability-zone"
-  }
-
-  placement_strategy {
-    type  = "spread"
-    field = "instanceId"
+    elb_name       = "${aws_elb.proxy.name}"
+    container_name = "teleport-proxy"
+    container_port = "3080"
   }
 }

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -36,4 +36,8 @@ resource "aws_ecs_service" "teleport_proxy" {
     container_name = "teleport-proxy"
     container_port = "3080"
   }
+
+  placement_constraints {
+    type = "distinctInstance"
+  }
 }

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -21,6 +21,7 @@ data "template_file" "teleport_proxy" {
     teleport_version   = "${var.teleport_version}"
     auth_servers       = "${data.aws_lb.nlb_node.dns_name}:3025"
     auth_token         = "${random_string.proxy_token.result}"
+    log_severity       = "${var.teleport_log_severity}"
   }
 }
 

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -17,8 +17,10 @@ data "template_file" "teleport_proxy" {
     memory_reservation = "${var.memory_reservation}"
     aws_region         = "${var.aws_region}"
     log_group          = "${aws_cloudwatch_log_group.teleport.id}"
+    cluster_name       = "${var.cluster_name}"
     teleport_version   = "${var.teleport_version}"
     auth_servers       = "${data.aws_lb.nlb_node.dns_name}:3025"
+    auth_token         = "${random_string.proxy_token.result}"
   }
 }
 
@@ -41,7 +43,7 @@ resource "aws_ecs_service" "teleport_proxy" {
     container_name   = "teleport-proxy"
     container_port   = "${local.ports[count.index]}"
   }
-  
+
   placement_strategy {
     type  = "spread"
     field = "attribute:ecs.availability-zone"

--- a/teleport-ecs/teleport-proxy.tf
+++ b/teleport-ecs/teleport-proxy.tf
@@ -1,0 +1,54 @@
+resource "aws_ecs_task_definition" "teleport_proxy" {
+  family                = "teleport-proxy"
+  container_definitions = "${data.template_file.teleport_proxy.rendered}"
+  network_mode          = "bridge"
+}
+
+data "aws_lb" "nlb_node" {
+  arn  = "${var.nlb_private_arn}"
+}
+
+data "template_file" "teleport_proxy" {
+  template = "${file("${path.module}/task-definitions/teleport-proxy.json")}"
+
+  vars {
+    cpu                = "${var.cpu}"
+    memory             = "${var.memory}"
+    memory_reservation = "${var.memory_reservation}"
+    aws_region         = "${var.aws_region}"
+    log_group          = "${aws_cloudwatch_log_group.teleport.id}"
+    teleport_version   = "${var.teleport_version}"
+    auth_servers       = "${data.aws_lb.nlb_node.dns_name}:3025"
+  }
+}
+
+locals {
+  ports = ["3023","3024","3080"]
+  functions = ["cli", "tunnel","web"]
+  targets = ["${module.nlb_cli.target_group_arn}","${module.nlb_tunnel.target_group_arn}","${module.target.target_group_arn}"]
+}
+
+
+resource "aws_ecs_service" "teleport_proxy" {
+  count           = 3
+  name            = "teleport-proxy-${local.functions[count.index]}"
+  cluster         = "${var.ecs_cluster}"
+  task_definition = "${aws_ecs_task_definition.teleport_proxy.arn}"
+  desired_count   = "${var.desired_count}"
+
+  load_balancer {
+    target_group_arn = "${local.targets[count.index]}"
+    container_name   = "teleport-proxy"
+    container_port   = "${local.ports[count.index]}"
+  }
+  
+  placement_strategy {
+    type  = "spread"
+    field = "attribute:ecs.availability-zone"
+  }
+
+  placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
+}

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_region" {
   description = "AWS region we are deploying in"
-  default = "eu-west-1"
+  default     = "eu-west-1"
 }
 
 variable "project" {
@@ -25,7 +25,7 @@ variable "memory_reservation" {
 
 variable "teleport_version" {
   description = "Teleport version you want to install"
-  default     = "2.3.7"
+  default     = "2.4.0"
 }
 
 variable "cluster_name" {
@@ -61,14 +61,6 @@ variable "domain_name" {
   description = "Domain name of where we want to reach our cluster. Example can be `company.com`"
 }
 
-variable "alb_listener_arn" {
-  description = "ARN for the ALB listener, this will be used to add a rule to for the Teleport web part"
-}
-
-variable "nlb_arn" {
-  description = "ARN for the NLB to create a listener for CLI and tunnel"
-}
-
 variable "nlb_private_arn" {
   description = "ARN for the private NLB to create a listener for the Node auth containers"
 }
@@ -77,12 +69,35 @@ variable "ecs_cluster" {
   description = "Name of the ECS cluster"
 }
 
-variable "desired_count" {
-  description = "Desired amount of containers we want to have running of each Teleport component"
-  default     = 1
-}
-
 variable "create_dns_record" {
   description = "Create DNS records to reach teleport"
   default     = "true"
+}
+
+variable "elb_subnets" {
+  description = "Subnets where to deploy the Teleport ELB"
+  type        = "list"
+}
+
+variable "web_ssl_certificate_arn" {
+  description = "ARN of the SSL certificate to use for the Teleport ELB"
+}
+
+variable "web_allowed_cidr_blocks" {
+  description = "CIDR blocks that are allowed to access the web interface of the proxy server"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "cli_allowed_cidr_blocks" {
+  description = "CIDR blocks that are allowed to access the cli interface of the proxy server"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tunnel_allowed_cidr_blocks" {
+  description = "CIDR blocks that are allowed to access the reverse tunnel interface of the proxy server"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "ecs_instances_sg_id" {
+  description = "Security group ID of the backend ECS instances running Teleport"
 }

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -15,12 +15,12 @@ variable "cpu" {
 
 variable "memory" {
   description = "The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
-  default     = "512"
+  default     = "128"
 }
 
 variable "memory_reservation" {
   description = "The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
-  default     = "254"
+  default     = "64"
 }
 
 variable "teleport_version" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -18,7 +18,7 @@ variable "memory_reservation" {
 }
 
 variable "teleport_version" {
-    default = "3.5.2"
+    default = "2.3.7"
 }
 
 variable "cluster_name" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_region" {
-  description = "AWS region we are deploying in"
+  description = "AWS region where the CloudWatch logs are going to be shipped, and where the DynamoDB table is going to be created. Defaults to eu-west-1"
   default     = "eu-west-1"
 }
 
@@ -50,11 +50,6 @@ variable "cluster_name" {
 variable "dynamodb_table" {
   description = "Which dynamodb table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform"
   default     = "main.teleport.auth"
-}
-
-variable "dynamodb_region" {
-  description = "In which region does the dynamodb table need to be created"
-  default     = "eu-west-1"
 }
 
 variable "tokens" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -10,7 +10,7 @@ variable "project" {
 
 variable "cpu" {
   description = "The number of CPU units used by the Teleport task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered."
-  default     = "128"
+  default     = "256"
 }
 
 variable "memory" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -66,7 +66,7 @@ variable "alb_listener_arn" {
 }
 
 variable "nlb_arn" {
-  description = "ARN for the NLB to create a listener for CLI and tunnel of Tunnelport"
+  description = "ARN for the NLB to create a listener for CLI and tunnel"
 }
 
 variable "nlb_private_arn" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -101,3 +101,8 @@ variable "tunnel_allowed_cidr_blocks" {
 variable "ecs_instances_sg_id" {
   description = "Security group ID of the backend ECS instances running Teleport"
 }
+
+variable "teleport_log_severity" {
+  description = "Logging configuration for Teleport, possible severity values are `INFO`, `WARN` and `ERROR`. Defaults to `ERROR`"
+  default     = "ERROR"
+}

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -18,7 +18,8 @@ variable "memory_reservation" {
 }
 
 variable "teleport_version" {
-  default = "2.3.7"
+  description = "Teleport version you want to install"
+  default     = "2.3.7"
 }
 
 variable "cluster_name" {
@@ -26,16 +27,19 @@ variable "cluster_name" {
 }
 
 variable "dynamodb_table" {
-  default = "main.teleport"
+  description = "Which dynamodb table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform"
+  default     = "main.teleport"
 }
 
 variable "dynamodb_region" {
-  default = "eu-west-1"
+  description = "In which region does the dynamodb table need to be created"
+  default     = "eu-west-1"
 }
 
 variable "tokens" {
-  type    = "list"
-  default = []
+  description = "List of tokens you want to add to the authentication server"
+  type        = "list"
+  default     = []
 }
 
 variable "environment" {
@@ -43,29 +47,35 @@ variable "environment" {
 }
 
 variable "vpc_id" {
-
+  description = "VPC ID of where we want to deploy Teleport in"
 }
 
 variable "domain_name" {
-
+  description = "Domain name of where we want to reach our cluster. Example can be `company.com`"
 }
 
 variable "alb_listener_arn" {
-
+  description = "ARN for the ALB listener, this will be used to add a rule to for the Teleport web part"
 }
 
 variable "nlb_arn" {
-
+  description = "ARN for the NLB to create a listener for CLI and tunnel of Tunnelport"
 }
 
 variable "nlb_private_arn" {
-
+  description = "ARN for the private NLB to create a listener for the Node auth containers"
 }
 
 variable "ecs_cluster" {
-
+  description = "Name of the ECS cluster"
 }
 
 variable "desired_count" {
-  default = 1
+  description = "Desired amount of containers we want to have running of each Teleport component"
+  default     = 1
+}
+
+variable "create_dns_record" {
+  description = "Create DNS records to reach teleport"
+  default     = "true"
 }

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -9,17 +9,32 @@ variable "project" {
 }
 
 variable "cpu" {
-  description = "The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered."
+  description = "The number of CPU units used by the Teleport task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered."
   default     = "128"
 }
 
 variable "memory" {
-  description = "The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
+  description = "The amount of memory (in MiB) used by the Teleport task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
   default     = "128"
 }
 
 variable "memory_reservation" {
-  description = "The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
+  description = "The soft limit (in MiB) of memory to reserve for the Teleport container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
+  default     = "64"
+}
+
+variable "cw_logs_cpu" {
+  description = "The number of CPU units used by the CloudWatch logs task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered."
+  default     = "128"
+}
+
+variable "cw_logs_memory" {
+  description = "The amount of memory (in MiB) used by the CloudWatch logs task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
+  default     = "128"
+}
+
+variable "cw_logs_memory_reservation" {
+  description = "The soft limit (in MiB) of memory to reserve for the CloudWatch logs container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
   default     = "64"
 }
 

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -18,7 +18,7 @@ variable "memory_reservation" {
 }
 
 variable "teleport_version" {
-    default = "2.3.7"
+  default = "2.3.7"
 }
 
 variable "cluster_name" {
@@ -26,15 +26,16 @@ variable "cluster_name" {
 }
 
 variable "dynamodb_table" {
-    default = "main.teleport"
+  default = "main.teleport"
 }
 
 variable "dynamodb_region" {
-    default = "eu-west-1"
+  default = "eu-west-1"
 }
 
 variable "tokens" {
-
+  type    = "list"
+  default = []
 }
 
 variable "environment" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -1,0 +1,70 @@
+variable "aws_region" {
+  default = "eu-west-1"
+}
+
+variable "project" {
+}
+
+variable "cpu" {
+  default = "512"
+}
+
+variable "memory" {
+  default = "1024"
+}
+
+variable "memory_reservation" {
+  default = "512"
+}
+
+variable "teleport_version" {
+    default = "3.5.2"
+}
+
+variable "cluster_name" {
+    
+}
+
+variable "dynamodb_table" {
+    default = "main.teleport"
+}
+
+variable "dynamodb_region" {
+    default = "eu-west-1"
+}
+
+variable "tokens" {
+    
+}
+
+variable "environment" {
+    
+}
+
+variable "vpc_id" {
+
+}
+
+variable "domain_name" {
+    
+}
+
+variable "alb_listener_arn" {
+    
+}
+
+variable "nlb_arn" {
+
+}
+
+variable "nlb_private_arn" {
+    
+}
+
+variable "ecs_cluster" {
+  
+} 
+
+variable "desired_count" {
+  default = 1
+}

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -6,15 +6,15 @@ variable "project" {
 }
 
 variable "cpu" {
-  default = "512"
+  default = "128"
 }
 
 variable "memory" {
-  default = "1024"
+  default = "512"
 }
 
 variable "memory_reservation" {
-  default = "512"
+  default = "254"
 }
 
 variable "teleport_version" {
@@ -22,7 +22,7 @@ variable "teleport_version" {
 }
 
 variable "cluster_name" {
-    
+
 }
 
 variable "dynamodb_table" {
@@ -34,11 +34,11 @@ variable "dynamodb_region" {
 }
 
 variable "tokens" {
-    
+
 }
 
 variable "environment" {
-    
+
 }
 
 variable "vpc_id" {
@@ -46,11 +46,11 @@ variable "vpc_id" {
 }
 
 variable "domain_name" {
-    
+
 }
 
 variable "alb_listener_arn" {
-    
+
 }
 
 variable "nlb_arn" {
@@ -58,12 +58,12 @@ variable "nlb_arn" {
 }
 
 variable "nlb_private_arn" {
-    
+
 }
 
 variable "ecs_cluster" {
-  
-} 
+
+}
 
 variable "desired_count" {
   default = 1

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -49,7 +49,7 @@ variable "cluster_name" {
 
 variable "dynamodb_table" {
   description = "Which dynamodb table does teleport need, teleport will create this table for you. You don't need to define anything in Terraform"
-  default     = "main.teleport"
+  default     = "main.teleport.auth"
 }
 
 variable "dynamodb_region" {

--- a/teleport-ecs/variables.tf
+++ b/teleport-ecs/variables.tf
@@ -1,20 +1,26 @@
 variable "aws_region" {
+  description = "AWS region we are deploying in"
   default = "eu-west-1"
 }
 
 variable "project" {
+  description = "Project where this node belongs to, will be the second part of the node name. Defaults to ''"
+  default     = ""
 }
 
 variable "cpu" {
-  default = "128"
+  description = "The number of CPU units used by the task. It can be expressed as an integer using CPU units, for example 1024, or as a string using vCPUs, for example 1 vCPU or 1 vcpu, in a task definition but will be converted to an integer indicating the CPU units when the task definition is registered."
+  default     = "128"
 }
 
 variable "memory" {
-  default = "512"
+  description = "The amount of memory (in MiB) used by the task. It can be expressed as an integer using MiB, for example 1024, or as a string using GB, for example 1GB or 1 GB, in a task definition but will be converted to an integer indicating the MiB when the task definition is registered."
+  default     = "512"
 }
 
 variable "memory_reservation" {
-  default = "254"
+  description = "The soft limit (in MiB) of memory to reserve for the container. When system memory is under contention, Docker attempts to keep the container memory to this soft limit; however, your container can consume more memory when it needs to, up to either the hard limit specified with the memory parameter (if applicable), or all of the available memory on the container instance, whichever comes first."
+  default     = "254"
 }
 
 variable "teleport_version" {
@@ -23,7 +29,7 @@ variable "teleport_version" {
 }
 
 variable "cluster_name" {
-
+  description = "Name of the cluster"
 }
 
 variable "dynamodb_table" {
@@ -43,7 +49,8 @@ variable "tokens" {
 }
 
 variable "environment" {
-
+  description = "Environment where this node belongs to, will be the third part of the node name. Defaults to ''"
+  default     = ""
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
This module will deploy Teleport auth and proxy servers on an ECS cluster.
It will also create an ELB in front of proxy.

See the module documentation in the Readme for a full description of what it does.