### PR TITLE
fixing ami selection filter

### DIFF
--- a/teleport-server/meta.tf
+++ b/teleport-server/meta.tf
@@ -18,11 +18,6 @@ data "aws_ami" "teleport_ami" {
   count       = "${length(var.ami_id) > 0 ? 0 : 1}"
   most_recent = true
 
-  filter {
-    name   = "tag:project"
-    values = ["teleport"]
-  }
-
   name_regex = "^ebs-teleport-*"
 
   owners = ["496014204152"]


### PR DESCRIPTION
Apparently the tag filter only works if the AMI belongs to your account, not if it's an external account.