### PR TITLE
Add support for upstart systems in the teleport-bootstrap-script module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ EOF
   # Start teleport
   part {
     content_type = "text/x-shellscript"
-    content      = "${replace(module.teleport_bootstrap_script.teleport_bootstrap_script, )}"
+    content      = "${module.teleport_bootstrap_script.teleport_bootstrap_script}"
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This module creates a script to configure and start the Teleport service on a se
 * [`project`]: String(optional): Project where this node belongs to, will be the second part of the node name. Defaults to ''
 * [`environment`]: String(optional): Environment where this node belongs to, will be the third part of the node name. Defaults to ''
 * [`include_instance_id`]: String(optional): If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled. Defaults to true
+* [`service_type`]: String(optional): Type of service to use for Teleport. Either systemd or upstart. Defaults to systemd
 
 ### Outputs
  * [`teleport_bootstrap_script`]: String: The rendered script to add to the Instance cloud-init user data.
@@ -32,7 +33,31 @@ ${teleport_service}
 ```
 
 ### Example
+
 ```
+data "template_cloudinit_config" "api_cloudinit" {
+  gzip          = true
+  base64_encode = true
+
+  # Configure teleport
+  part {
+    content_type = "text/cloud-config"
+    content =<<EOF
+#cloud-config
+
+write_files:
+${module.teleport_bootstrap_script.teleport_config_cloudinit}
+${module.teleport_bootstrap_script.teleport_service_cloudinit}
+EOF
+  }
+
+  # Start teleport
+  part {
+    content_type = "text/x-shellscript"
+    content      = "${replace(module.teleport_bootstrap_script.teleport_bootstrap_script, )}"
+  }
+}
+
 module "teleport_bootstrap_script" {
   source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=1.0.0"
   auth_server = "tools01.customer.skyscrape.rs:3025"

--- a/teleport-bootstrap-script/main.tf
+++ b/teleport-bootstrap-script/main.tf
@@ -12,7 +12,7 @@ data "template_file" "teleport_bootstrap_script" {
 }
 
 data "template_file" "teleport_service" {
-  template = "${file("${path.module}/templates/teleport.service")}"
+  template = "${file("${path.module}/templates/${var.service_type == "systemd" ? "teleport.service" : "teleport-upstart.conf"}")}"
 }
 
 data "template_file" "teleport_config" {
@@ -29,7 +29,8 @@ data "template_file" "teleport_service_cloudinit" {
   template = "${file("${path.module}/templates/teleport.service.tpl")}"
 
   vars {
-    teleport_service = "${indent(4,data.template_file.teleport_service.rendered)}"
+    teleport_service  = "${indent(4,data.template_file.teleport_service.rendered)}"
+    service_type_path = "${var.service_type == "systemd" ? "/lib/systemd/system/teleport.service" : "/etc/init.d/teleport"}"
   }
 }
 

--- a/teleport-bootstrap-script/main.tf
+++ b/teleport-bootstrap-script/main.tf
@@ -11,10 +11,6 @@ data "template_file" "teleport_bootstrap_script" {
   }
 }
 
-data "template_file" "teleport_service" {
-  template = "${file("${path.module}/templates/${var.service_type == "systemd" ? "teleport.service" : "teleport-upstart.conf"}")}"
-}
-
 data "template_file" "teleport_config" {
   template = "${file("${path.module}/templates/teleport.yaml.tpl")}"
 
@@ -29,7 +25,7 @@ data "template_file" "teleport_service_cloudinit" {
   template = "${file("${path.module}/templates/teleport.service.tpl")}"
 
   vars {
-    teleport_service  = "${indent(4,data.template_file.teleport_service.rendered)}"
+    teleport_service  = "${indent(4,file("${path.module}/templates/${var.service_type == "systemd" ? "teleport.service" : "teleport-upstart.conf"}"))}"
     service_type_path = "${var.service_type == "systemd" ? "/lib/systemd/system/teleport.service" : "/etc/init.d/teleport"}"
   }
 }

--- a/teleport-bootstrap-script/main.tf
+++ b/teleport-bootstrap-script/main.tf
@@ -27,6 +27,7 @@ data "template_file" "teleport_service_cloudinit" {
   vars {
     teleport_service  = "${indent(4,file("${path.module}/templates/${var.service_type == "systemd" ? "teleport.service" : "teleport-upstart.conf"}"))}"
     service_type_path = "${var.service_type == "systemd" ? "/lib/systemd/system/teleport.service" : "/etc/init.d/teleport"}"
+    file_permissions  = "${var.service_type == "systemd" ? "0644" : "0755"}"
   }
 }
 

--- a/teleport-bootstrap-script/templates/metadata.tpl
+++ b/teleport-bootstrap-script/templates/metadata.tpl
@@ -26,11 +26,15 @@ echo "AUTH_TOKEN=${auth_token}" >> /etc/teleport
 echo "AUTH_SERVER=${auth_server}" >> /etc/teleport
 echo "NODENAME=${function}${project}${environment}$INSTANCE_ID" >> /etc/teleport
 
-# Reload systemd to activate teleport service
-sudo systemctl daemon-reload
+if [ -f /etc/init.d/teleport ] && ! [ -x "$(command -v systemctl)" ]; then
+  sudo /etc/init.d/teleport start
+else
+  # Reload systemd to activate teleport service
+  sudo systemctl daemon-reload
 
-# Enable teleport service
-sudo systemctl enable teleport.service
+  # Enable teleport service
+  sudo systemctl enable teleport.service
 
-# Start teleport service
-sudo systemctl start teleport.service
+  # Start teleport service
+  sudo systemctl start teleport.service
+fi

--- a/teleport-bootstrap-script/templates/teleport-upstart.conf
+++ b/teleport-bootstrap-script/templates/teleport-upstart.conf
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+#       /etc/rc.d/init.d/teleport
+#
+#       Daemonize the teleport agent.
+#
+# chkconfig:   2345 95 20
+# description: SSH Infrastructure for clusters and teams
+# processname: teleport
+# pidfile: /var/run/teleport/pidfile
+
+# Source function library.
+. /etc/init.d/functions
+
+TELEPORT=/usr/local/bin/teleport
+CONFIG=/etc/teleport.yaml
+PID_FILE=/var/run/teleport/teleport.pid
+LOG_FILE=/var/log/teleport.log
+
+# Source configuration variables
+[ -e /etc/teleport ] && . /etc/teleport
+
+export GOMAXPROCS=${GOMAXPROCS:-2}
+
+#
+# Create the /var/run/consul directory, which can live on a tmpfs
+# filesystem and be destroyed between reboots.
+#
+mkrundir() {
+        [ ! -d /var/run/teleport ] && mkdir -p /var/run/teleport
+}
+
+#
+# Create a PID file if it doesn't already exist, for clean upgrades
+# from previous init-script controlled daemons.
+#
+KILLPROC_OPT="-p ${PID_FILE}"
+mkpidfile() {
+        # Create PID file if it didn't exist
+        mkrundir
+        [ ! -f $PID_FILE ] && pidofproc $CONSUL > $PID_FILE
+        if [ $? -ne 0 ] ; then
+            rm $PID_FILE
+            KILLPROC_OPT=""
+        fi
+}
+
+start() {
+        echo -n "Starting teleport: "
+        mkrundir
+        [ -f $PID_FILE ] && rm $PID_FILE
+        daemon --pidfile="$PID_FILE" \
+            "$TELEPORT" start --config="$CONFIG" --nodename $NODENAME --advertise-ip $ADVERTISE_IP --auth-server $AUTH_SERVER --token $AUTH_TOKEN >> "$LOG_FILE" &
+        retcode=$?
+        sleep 1 # Give teleport a change to start before writing PID
+        PID=$(pgrep teleport)
+        echo $PID >> $PID_FILE
+        touch /var/lock/subsys/teleport
+        return $retcode
+}
+
+stop() {
+        DELAY=5 # seconds maximum to wait for a leave
+
+        echo -n "Shutting down teleport: "
+        mkpidfile
+
+        killproc $KILLPROC_OPT $TELEPORT
+        retcode=$?
+
+        rm -f /var/lock/subsys/teleport $PID_FILE
+        return $retcode
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status -p $PID_FILE teleport
+        ;;
+    restart)
+        stop
+        start
+        ;;
+    reload)
+        mkpidfile
+        killproc $KILLPROC_OPT $TELEPORT -HUP
+        ;;
+    condrestart)
+        [ -f /var/lock/subsys/teleport ] && restart || :
+        ;;
+    *)
+        echo "Usage: teleport {start|stop|status|reload|restart}"
+        exit 1
+        ;;
+esac
+retcode=$?
+# Don't let the [OK] get stomped on.
+echo
+exit $retcode

--- a/teleport-bootstrap-script/templates/teleport.service.tpl
+++ b/teleport-bootstrap-script/templates/teleport.service.tpl
@@ -1,3 +1,4 @@
 - content: |
     ${teleport_service}
   path: ${service_type_path}
+  permissions: '${file_permissions}'

--- a/teleport-bootstrap-script/templates/teleport.service.tpl
+++ b/teleport-bootstrap-script/templates/teleport.service.tpl
@@ -1,3 +1,3 @@
 - content: |
     ${teleport_service}
-  path: /lib/systemd/system/teleport.service
+  path: ${service_type_path}

--- a/teleport-bootstrap-script/variables.tf
+++ b/teleport-bootstrap-script/variables.tf
@@ -24,3 +24,8 @@ variable "include_instance_id" {
   description = "If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled. Defaults to true"
   default     = "true"
 }
+
+variable "service_type" {
+  description = "Type of service to use for Teleport. Either systemd or upstart"
+  default     = "systemd"
+}


### PR DESCRIPTION
This is needed for the ECS optimized instances from AWS, as they are based on AWS Linux 1.0 and use upstart.

This is also needed for https://github.com/skyscrapers/frisket/pull/59

I've also extended a bit the example in the readme