### PR TITLE
changes added to catch all logs from teleport

### DIFF
--- a/teleport-server/templates/cloud-init.yaml.tpl
+++ b/teleport-server/templates/cloud-init.yaml.tpl
@@ -167,7 +167,7 @@ write_files:
     state_file = /var/awslogs/state/agent-state
     [teleport_audit_log]
     datetime_format = %b %d %H:%M:%S
-    file = /var/lib/teleport/log/*.log
+    file = /var/lib/teleport/log/*/*.log
     buffer_duration = 5000
     log_stream_name = {instance_id}
     initial_position = start_of_file


### PR DESCRIPTION
The log path has changed in the recent version of Teleport, thats why I have modified the path. 
 Thanks for @venturel  for the help on this