### PR TITLE
Open NTP port to the outside world in teleport server security group

### DIFF
--- a/teleport-server/sg.tf
+++ b/teleport-server/sg.tf
@@ -149,3 +149,13 @@ resource "aws_security_group_rule" "internet_https_access" {
   security_group_id = "${aws_security_group.teleport_server.id}"
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "ntp" {
+  description       = "NTP (clock synchronization)"
+  type              = "egress"
+  from_port         = 123
+  to_port           = 123
+  protocol          = "udp"
+  security_group_id = "${aws_security_group.teleport_server.id}"
+  cidr_blocks       = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
Without this, the clock in the Teleport server can get out of sync, which causes the MFA to not work properly.