### PR TITLE
Allow operations on the DynamoDB table indexes as well

### DIFF
--- a/teleport-server/iam.tf
+++ b/teleport-server/iam.tf
@@ -63,7 +63,9 @@ data "aws_iam_policy_document" "teleport" {
 
     resources = [
       "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}",
+      "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}/*",        # also allow operations on the table indexes
       "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}_events",
+      "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}_events/*", # also allow operations on the table indexes
     ]
   }
 

--- a/teleport-server/templates/cloud-init.yaml.tpl
+++ b/teleport-server/templates/cloud-init.yaml.tpl
@@ -39,7 +39,7 @@ write_files:
         type: dynamodb
         region: ${teleport_dynamodb_region}
         table_name: ${teleport_dynamodb_table}
-        audit_events_uri: ["file:///var/lib/teleport/audit/events", "dynamodb://${teleport_dynamodb_table}_events"]
+        audit_events_uri: ["dynamodb://${teleport_dynamodb_table}_events", "file:///var/lib/teleport/audit/events"]
         audit_sessions_uri: "s3://${recorded_sessions_bucket_name}/teleport.events"
 
     # This section configures the 'auth service':


### PR DESCRIPTION
This allows the teleport server to operate on the DynamoDB table indexes.

Also change the order of the `audit_events_uri` locations. The local file path has to be specified after the dynamodb, so Teleport defaults to DynamoDB when it starts to fetch the audit events data.