### PR TITLE
Support Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Terraform module to provision Teleport related resources.
 
+Starting from version 5.0.0, this module uses Terraform 0.12 syntax.
+
 ## teleport-bootstrap-script
 
 This module creates a script to configure and start the Teleport service on a server. It's useful on pre-built images, where everything is already setup on build-time but Teleport still needs to be configured with the actual node information, like private IP, node name and `auth` credentials. It uses `envsubst` to set the correct configuration into `/etc/teleport.yaml`, so the following environment variables need to be present in that file before running this script:
@@ -15,12 +17,12 @@ This module creates a script to configure and start the Teleport service on a se
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| additional\_labels | List of additional labels to add to the Teleport node. Every list item represents a label, with its key and value. Example: `["k8s_version: 1.10.10", "instance_type: t2.medium"]` | list | `<list>` | no |
+| additional\_labels | List of additional labels to add to the Teleport node. Every list item represents a label, with its key and value. Example: `["k8s_version: 1.10.10", "instance_type: t2.medium"]` | list(string) | `[]` | no |
 | auth\_server | Auth server that this node will connect to, including the port number | string | n/a | yes |
 | auth\_token | Auth token that this node will present to the auth server. **Note** that this should be the bare token, without the type prefix. See the official [documentation on static tokens](https://gravitational.com/teleport/docs/2.3/admin-guide/#static-tokens) for more info | string | n/a | yes |
 | environment | Environment where this node belongs to, will be the third part of the node name | string | `""` | no |
 | function | Function that this node performs, will be the first part of the node name | string | n/a | yes |
-| include\_instance\_id | If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled | string | `"true"` | no |
+| include\_instance\_id | If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled | bool | `true` | no |
 | project | Project where this node belongs to, will be the second part of the node name | string | `""` | no |
 
 ### Outputs
@@ -95,28 +97,28 @@ These are the requirements to apply this module:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acme_server | ACME server where to point `certbot` on the Teleport server to fetch an SSL certificate. Useful if you want to point to the letsencrypt staging server | string | `https://acme-v01.api.letsencrypt.org/directory` | no |
-| allowed_cli_cidr_blocks | CIDR blocks that are allowed to access the cli interface of the `proxy` server | string | `<list>` | no |
-| allowed_node_cidr_blocks | CIDR blocks that are allowed to access the API interface in the `auth` server | string | `<list>` | no |
-| allowed_tunnel_cidr_blocks | CIDR blocks that are allowed to access the reverse tunnel interface of the `proxy` server | string | `<list>` | no |
-| allowed_web_cidr_blocks | CIDR blocks that are allowed to access the web interface of the `proxy` server | string | `<list>` | no |
-| ami_id | AMI id for the EC2 instance | string | `` | no |
+| allowed_cli_cidr_blocks | CIDR blocks that are allowed to access the cli interface of the `proxy` server | list(string) | `["0.0.0.0/0"]` | no |
+| allowed_node_cidr_blocks | CIDR blocks that are allowed to access the API interface in the `auth` server | list(string) | `["0.0.0.0/0"]` | no |
+| allowed_tunnel_cidr_blocks | CIDR blocks that are allowed to access the reverse tunnel interface of the `proxy` server | list(string) | `["0.0.0.0/0"]` | no |
+| allowed_web_cidr_blocks | CIDR blocks that are allowed to access the web interface of the `proxy` server | list(string) | `["0.0.0.0/0"]` | no |
+| ami_id | AMI id for the EC2 instance | string | `""` | no |
 | environment | The environment where this setup belongs to. Only for naming reasons | string | - | yes |
-| instance_type | Instance type for the EC2 instance | string | `t2.small` | no |
+| instance_type | Instance type for the EC2 instance | string | `"t2.small"` | no |
 | key_name | SSH key name for the EC2 instance | string | - | yes |
-| letsencrypt_email | Email to use to register to letsencrypt | string | `letsencrypt@skyscrapers.eu` | no |
+| letsencrypt_email | Email to use to register to letsencrypt | string | `"letsencrypt@skyscrapers.eu"` | no |
 | project | A project where this setup belongs to. Only for naming reasons | string | - | yes |
 | r53_zone | The Route53 zone where to add the Teleport DNS record | string | - | yes |
-| root_vl_delete | Whether the root volume of the EC2 instance should be destroyed on instance termination | string | `true` | no |
-| root_vl_size | Volume size for the root volume of the EC2 instance, in gigabytes | string | `16` | no |
-| root_vl_type | Volume type for the root volume of the EC2 instance. Can be `standard`, `gp2`, or `io1` | string | `gp2` | no |
+| root_vl_delete | Whether the root volume of the EC2 instance should be destroyed on instance termination | bool | `true` | no |
+| root_vl_size | Volume size for the root volume of the EC2 instance, in gigabytes | number | `16` | no |
+| root_vl_type | Volume type for the root volume of the EC2 instance. Can be `standard`, `gp2`, or `io1` | string | `"gp2"` | no |
 | subnet_id | Subnet id where the EC2 instance will be deployed | string | - | yes |
-| teleport_auth_tokens | List of static tokens to configure in the Teleport server. **Note** that these tokens will be added "as-is" in the Teleport configuration, so they must be pre-fixed with the token type (e.g. `teleport_auth_tokens = ["node:sdf34asd7f832efhsdnfsjdfh3i24788923r"]`). See the official [documentation on static tokens](https://gravitational.com/teleport/docs/admin-guide/#static-tokens) for more info | string | `<list>` | no |
-| teleport_cluster_name | Name of the teleport cluster | string | `` | no |
-| teleport_dynamodb_table | Name of the DynamoDB table to configure in Teleport | string | `` | no |
-| teleport_log_output | Teleport logging configuration, possible values are `stdout`, `stderr` and `syslog` | string | `stdout` | no |
-| teleport_log_severity | Teleport logging configuration, possible severity values are `INFO`, `WARN` and `ERROR` | string | `ERROR` | no |
-| teleport_session_recording | Setting for configuring session recording in Teleport. Check the [official documentation](https://gravitational.com/teleport/docs/admin-guide/#configuration) for more info | string | `node` | no |
-| teleport_subdomain | DNS subdomain that will be created for the teleport server | string | `teleport` | no |
+| teleport_auth_tokens | List of static tokens to configure in the Teleport server. **Note** that these tokens will be added "as-is" in the Teleport configuration, so they must be pre-fixed with the token type (e.g. `teleport_auth_tokens = ["node:sdf34asd7f832efhsdnfsjdfh3i24788923r"]`). See the official [documentation on static tokens](https://gravitational.com/teleport/docs/admin-guide/#static-tokens) for more info | list(string) | `[]` | no |
+| teleport_cluster_name | Name of the teleport cluster | string | `""` | no |
+| teleport_dynamodb_table | Name of the DynamoDB table to configure in Teleport | string | `""` | no |
+| teleport_log_output | Teleport logging configuration, possible values are `stdout`, `stderr` and `syslog` | string | `"stdout"` | no |
+| teleport_log_severity | Teleport logging configuration, possible severity values are `INFO`, `WARN` and `ERROR` | string | `"ERROR"` | no |
+| teleport_session_recording | Setting for configuring session recording in Teleport. Check the [official documentation](https://gravitational.com/teleport/docs/admin-guide/#configuration) for more info | string | `"node"` | no |
+| teleport_subdomain | DNS subdomain that will be created for the teleport server | string | `"teleport"` | no |
 
 ### Outputs
 

--- a/teleport-bootstrap-script/main.tf
+++ b/teleport-bootstrap-script/main.tf
@@ -1,35 +1,45 @@
 data "template_file" "teleport_bootstrap_script" {
-  template = "${file("${path.module}/templates/metadata.tpl")}"
+  template = file("${path.module}/templates/metadata.tpl")
 
-  vars {
-    function            = "${var.function}"
-    project             = "${var.project == "" ? "" : "-${var.project}"}"
-    environment         = "${var.environment == "" ? "" : "-${var.environment}"}"
-    include_instance_id = "${var.include_instance_id}"
-    auth_token          = "${var.auth_token}"
-    auth_server         = "${var.auth_server}"
+  vars = {
+    function            = var.function
+    project             = var.project == "" ? "" : "-${var.project}"
+    environment         = var.environment == "" ? "" : "-${var.environment}"
+    include_instance_id = var.include_instance_id
+    auth_token          = var.auth_token
+    auth_server         = var.auth_server
   }
 }
 
 locals {
-  environment_label = "${var.environment == "" ? "" : "environment: ${var.environment}" }"
-  project_label     = "${var.project == "" ? "" : "project: ${var.project}" }"
-  function_label    = "${var.function == "" ? "" : "function: ${var.function}" }"
-  default_labels    = "${list(local.environment_label, local.project_label, local.function_label)}"
+  environment_label = var.environment == "" ? "" : "environment: ${var.environment}"
+  project_label     = var.project == "" ? "" : "project: ${var.project}"
+  function_label    = var.function == "" ? "" : "function: ${var.function}"
+  default_labels = [
+    local.environment_label,
+    local.project_label,
+    local.function_label,
+  ]
 }
 
 data "template_file" "teleport_config" {
-  template = "${file("${path.module}/templates/teleport.yaml.tpl")}"
+  template = file("${path.module}/templates/teleport.yaml.tpl")
 
-  vars {
-    labels = "${indent(4, join("\n", distinct(compact(concat(local.default_labels, var.additional_labels)))))}"
+  vars = {
+    labels = indent(
+      4,
+      join(
+        "\n",
+        distinct(compact(concat(local.default_labels, var.additional_labels))),
+      ),
+    )
   }
 }
 
 data "template_file" "teleport_config_cloudinit" {
-  template = "${file("${path.module}/templates/teleport-cloudinit.yaml.tpl")}"
+  template = file("${path.module}/templates/teleport-cloudinit.yaml.tpl")
 
-  vars {
-    teleport_config = "${indent(4,data.template_file.teleport_config.rendered)}"
+  vars = {
+    teleport_config = indent(4, data.template_file.teleport_config.rendered)
   }
 }

--- a/teleport-bootstrap-script/outputs.tf
+++ b/teleport-bootstrap-script/outputs.tf
@@ -1,14 +1,14 @@
 output "teleport_bootstrap_script" {
   description = "The rendered script to add to the Instance cloud-init user data"
-  value       = "${data.template_file.teleport_bootstrap_script.rendered}"
+  value       = data.template_file.teleport_bootstrap_script.rendered
 }
 
 output "teleport_config_cloudinit" {
   description = "The rendered Teleport config that you can add to the instance cloud-init user data"
-  value       = "${data.template_file.teleport_config_cloudinit.rendered}"
+  value       = data.template_file.teleport_config_cloudinit.rendered
 }
 
 output "teleport_service_cloudinit" {
   description = "The rendered Teleport systemd service that you can add to the instance cloud-init user data"
-  value       = "${file("${path.module}/templates/teleport.service.yaml")}"
+  value       = file("${path.module}/templates/teleport.service.yaml")
 }

--- a/teleport-bootstrap-script/templates/metadata.tpl
+++ b/teleport-bootstrap-script/templates/metadata.tpl
@@ -19,7 +19,7 @@ get_private_ip () {
 echo "ADVERTISE_IP=$(get_private_ip)" >> /etc/teleport
 
 ## Get instance ID (if possible)
-${include_instance_id == "true" ? "export INSTANCE_ID=-$(curl -s http://169.254.169.254/latest/meta-data/instance-id)" : ""}
+${include_instance_id ? "export INSTANCE_ID=-$(curl -s http://169.254.169.254/latest/meta-data/instance-id)" : ""}
 
 ## Set the rest of the config
 echo "AUTH_TOKEN=${auth_token}" >> /etc/teleport

--- a/teleport-bootstrap-script/variables.tf
+++ b/teleport-bootstrap-script/variables.tf
@@ -26,7 +26,7 @@ variable "include_instance_id" {
 }
 
 variable "additional_labels" {
-  type        = "list"
+  type        = list(string)
   description = "List of additional labels to add to the Teleport node. Every list item represents a label, with its key and value. Example: `[\"k8s_version: 1.10.10\", \"instance_type: t2.medium\"]`"
   default     = []
 }

--- a/teleport-bootstrap-script/variables.tf
+++ b/teleport-bootstrap-script/variables.tf
@@ -1,28 +1,34 @@
 variable "auth_server" {
+  type        = string
   description = "Auth server that this node will connect to, including the port number"
 }
 
 variable "auth_token" {
+  type        = string
   description = "Auth token that this node will present to the auth server. **Note** that this should be the bare token, without the type prefix. See the official [documentation on static tokens](https://gravitational.com/teleport/docs/2.3/admin-guide/#static-tokens) for more info"
 }
 
 variable "function" {
+  type        = string
   description = "Function that this node performs, will be the first part of the node name"
 }
 
 variable "project" {
+  type        = string
   description = "Project where this node belongs to, will be the second part of the node name"
   default     = ""
 }
 
 variable "environment" {
+  type        = string
   description = "Environment where this node belongs to, will be the third part of the node name"
   default     = ""
 }
 
 variable "include_instance_id" {
+  type        = bool
   description = "If running in EC2, also include the instance ID in the node name. This is needed in autoscaled environments, so nodes don't collide with each other if they get recycled/autoscaled"
-  default     = "true"
+  default     = true
 }
 
 variable "additional_labels" {

--- a/teleport-bootstrap-script/versions.tf
+++ b/teleport-bootstrap-script/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/teleport-node-sg-rules/main.tf
+++ b/teleport-node-sg-rules/main.tf
@@ -3,8 +3,8 @@ resource "aws_security_group_rule" "teleport_nodes_from_proxy" {
   from_port                = 3022
   to_port                  = 3022
   protocol                 = "tcp"
-  source_security_group_id = "${var.teleport_proxy_sg_id}"
-  security_group_id        = "${var.teleport_node_sg_id}"
+  source_security_group_id = var.teleport_proxy_sg_id
+  security_group_id        = var.teleport_node_sg_id
 }
 
 resource "aws_security_group_rule" "teleport_nodes_to_auth" {
@@ -12,6 +12,6 @@ resource "aws_security_group_rule" "teleport_nodes_to_auth" {
   from_port                = 3025
   to_port                  = 3025
   protocol                 = "tcp"
-  source_security_group_id = "${var.teleport_auth_sg_id}"
-  security_group_id        = "${var.teleport_node_sg_id}"
+  source_security_group_id = var.teleport_auth_sg_id
+  security_group_id        = var.teleport_node_sg_id
 }

--- a/teleport-node-sg-rules/variables.tf
+++ b/teleport-node-sg-rules/variables.tf
@@ -1,11 +1,14 @@
 variable "teleport_proxy_sg_id" {
+  type        = string
   description = "Security group id of the `proxy` server."
 }
 
 variable "teleport_node_sg_id" {
+  type        = string
   description = "Security group id of the `node` server."
 }
 
 variable "teleport_auth_sg_id" {
+  type        = string
   description = "Security group id of the `auth` server."
 }

--- a/teleport-node-sg-rules/versions.tf
+++ b/teleport-node-sg-rules/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/teleport-server/cwlogs.tf
+++ b/teleport-server/cwlogs.tf
@@ -2,8 +2,8 @@ resource "aws_cloudwatch_log_group" "teleport" {
   name              = "teleport_log"
   retention_in_days = "30"
 
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
     Application = "Teleport"
   }
 }
@@ -12,8 +12,8 @@ resource "aws_cloudwatch_log_group" "teleport_audit" {
   name              = "teleport_audit_log"
   retention_in_days = "30"
 
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
     Application = "Teleport"
   }
 }

--- a/teleport-server/iam.tf
+++ b/teleport-server/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_instance_profile" "profile" {
   name_prefix = "teleport-${var.project}-${var.environment}-"
-  role        = "${aws_iam_role.role.name}"
+  role        = aws_iam_role.role.name
 }
 
 resource "aws_iam_role" "role" {
@@ -24,8 +24,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "policy" {
-  role   = "${aws_iam_role.role.id}"
-  policy = "${data.aws_iam_policy_document.teleport.json}"
+  role = aws_iam_role.role.id
+  policy = data.aws_iam_policy_document.teleport.json
 }
 
 data "aws_iam_policy_document" "teleport" {
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "teleport" {
 
     resources = [
       "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}",
-      "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}/*",        # also allow operations on the table indexes
+      "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}/*", # also allow operations on the table indexes
       "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}_events",
       "arn:aws:dynamodb:${data.aws_region.current.name}:*:table/${local.teleport_dynamodb_table}_events/*", # also allow operations on the table indexes
     ]
@@ -81,9 +81,9 @@ data "aws_iam_policy_document" "teleport" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.teleport_audit.arn}",
+      aws_cloudwatch_log_group.teleport_audit.arn,
       "${aws_cloudwatch_log_group.teleport_audit.arn}:*",
-      "${aws_cloudwatch_log_group.teleport.arn}",
+      aws_cloudwatch_log_group.teleport.arn,
       "${aws_cloudwatch_log_group.teleport.arn}:*",
     ]
   }
@@ -109,7 +109,7 @@ data "aws_iam_policy_document" "teleport" {
     ]
 
     resources = [
-      "${aws_s3_bucket.sessions.arn}",
+      aws_s3_bucket.sessions.arn,
     ]
   }
 }

--- a/teleport-server/instance.tf
+++ b/teleport-server/instance.tf
@@ -1,36 +1,36 @@
 module "is_ebs_optimised" {
   source        = "github.com/skyscrapers/terraform-instances//is_ebs_optimised?ref=2.3.5"
-  instance_type = "${var.instance_type}"
+  instance_type = var.instance_type
 }
 
 resource "aws_instance" "teleport_instance" {
-  ami                         = "${length(var.ami_id) > 0 ? var.ami_id : join("", data.aws_ami.teleport_ami.*.image_id)}"
-  instance_type               = "${var.instance_type}"
-  key_name                    = "${var.key_name}"
-  iam_instance_profile        = "${aws_iam_instance_profile.profile.id}"
-  vpc_security_group_ids      = ["${aws_security_group.teleport_server.id}"]
-  subnet_id                   = "${var.subnet_id}"
+  ami                         = length(var.ami_id) > 0 ? var.ami_id : join("", data.aws_ami.teleport_ami.*.image_id)
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  iam_instance_profile        = aws_iam_instance_profile.profile.id
+  vpc_security_group_ids      = [aws_security_group.teleport_server.id]
+  subnet_id                   = var.subnet_id
   disable_api_termination     = "false"
-  ebs_optimized               = "${module.is_ebs_optimised.is_ebs_optimised}"
+  ebs_optimized               = module.is_ebs_optimised.is_ebs_optimised
   associate_public_ip_address = "true"
-  user_data                   = "${data.template_cloudinit_config.teleport.rendered}"
+  user_data                   = data.template_cloudinit_config.teleport.rendered
 
   root_block_device {
-    volume_type           = "${var.root_vl_type}"
-    volume_size           = "${var.root_vl_size}"
-    delete_on_termination = "${var.root_vl_delete}"
+    volume_type           = var.root_vl_type
+    volume_size           = var.root_vl_size
+    delete_on_termination = var.root_vl_delete
   }
 
-  tags {
+  tags = {
     Name        = "teleport-${var.project}-${var.environment}"
     Stack       = "teleport"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
+    Project     = var.project
+    Environment = var.environment
   }
 }
 
 resource "aws_eip" "teleport_public" {
-  instance = "${aws_instance.teleport_instance.id}"
+  instance = aws_instance.teleport_instance.id
   vpc      = true
 }
 
@@ -40,27 +40,33 @@ data "template_cloudinit_config" "teleport" {
 
   part {
     content_type = "text/cloud-config"
-    content      = "${data.template_file.cloudinit_teleport.rendered}"
+    content      = data.template_file.cloudinit_teleport.rendered
   }
 }
 
 data "template_file" "cloudinit_teleport" {
-  template = "${file("${path.module}/templates/cloud-init.yaml.tpl")}"
+  template = file("${path.module}/templates/cloud-init.yaml.tpl")
 
-  vars {
-    letsencrypt_email             = "${var.letsencrypt_email}"
-    teleport_domain_name          = "${local.teleport_domain_name}"
-    teleport_log_output           = "${var.teleport_log_output}"
-    teleport_log_severity         = "${var.teleport_log_severity}"
-    teleport_dynamodb_region      = "${data.aws_region.current.name}"
-    teleport_dynamodb_table       = "${local.teleport_dynamodb_table}"
-    teleport_auth_tokens          = "${length(var.teleport_auth_tokens) > 0 ? indent(6, join("\n", concat(list("tokens:"), formatlist("- %s", var.teleport_auth_tokens)))) : ""}"
-    teleport_cluster_name         = "${local.teleport_cluster_name}"
-    teleport_session_recording    = "${var.teleport_session_recording}"
-    acme_server                   = "${var.acme_server}"
-    recorded_sessions_bucket_name = "${aws_s3_bucket.sessions.id}"
-    project                       = "${var.project}"
-    environment                   = "${var.environment}"
-    instance_type                 = "${var.instance_type}"
+  vars = {
+    letsencrypt_email        = var.letsencrypt_email
+    teleport_domain_name     = local.teleport_domain_name
+    teleport_log_output      = var.teleport_log_output
+    teleport_log_severity    = var.teleport_log_severity
+    teleport_dynamodb_region = data.aws_region.current.name
+    teleport_dynamodb_table  = local.teleport_dynamodb_table
+    teleport_auth_tokens = length(var.teleport_auth_tokens) > 0 ? indent(
+      6,
+      join(
+        "\n",
+        concat(["tokens:"], formatlist("- %s", var.teleport_auth_tokens)),
+      ),
+    ) : ""
+    teleport_cluster_name         = local.teleport_cluster_name
+    teleport_session_recording    = var.teleport_session_recording
+    acme_server                   = var.acme_server
+    recorded_sessions_bucket_name = aws_s3_bucket.sessions.id
+    project                       = var.project
+    environment                   = var.environment
+    instance_type                 = var.instance_type
   }
 }

--- a/teleport-server/meta.tf
+++ b/teleport-server/meta.tf
@@ -1,21 +1,22 @@
 locals {
   teleport_domain_name    = "${var.teleport_subdomain}.${var.r53_zone}"
-  teleport_dynamodb_table = "${length(var.teleport_dynamodb_table) > 0 ? var.teleport_dynamodb_table : local.teleport_domain_name}"
-  teleport_cluster_name   = "${length(var.teleport_cluster_name) > 0 ? var.teleport_cluster_name : local.teleport_domain_name}"
+  teleport_dynamodb_table = length(var.teleport_dynamodb_table) > 0 ? var.teleport_dynamodb_table : local.teleport_domain_name
+  teleport_cluster_name   = length(var.teleport_cluster_name) > 0 ? var.teleport_cluster_name : local.teleport_domain_name
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 data "aws_route53_zone" "root" {
-  name = "${var.r53_zone}"
+  name = var.r53_zone
 }
 
 data "aws_subnet" "teleport" {
-  id = "${var.subnet_id}"
+  id = var.subnet_id
 }
 
 data "aws_ami" "teleport_ami" {
-  count       = "${length(var.ami_id) > 0 ? 0 : 1}"
+  count       = length(var.ami_id) > 0 ? 0 : 1
   most_recent = true
 
   name_regex = "^ebs-teleport-*"

--- a/teleport-server/outputs.tf
+++ b/teleport-server/outputs.tf
@@ -1,54 +1,54 @@
 output "teleport_server_sg_id" {
   description = "Security group id of the Teleport server."
-  value       = "${aws_security_group.teleport_server.id}"
+  value       = aws_security_group.teleport_server.id
 }
 
 output "teleport_server_instance_id" {
   description = "Instance id of the Teleport server."
-  value       = "${aws_instance.teleport_instance.id}"
+  value       = aws_instance.teleport_instance.id
 }
 
 output "teleport_server_public_ip" {
   description = "Public IP of the Teleport server."
-  value       = "${aws_eip.teleport_public.public_ip}"
+  value       = aws_eip.teleport_public.public_ip
 }
 
 output "teleport_server_private_ip" {
   description = "Private IP of the Teleport server."
-  value       = "${aws_eip.teleport_public.private_ip}"
+  value       = aws_eip.teleport_public.private_ip
 }
 
 output "teleport_server_fqdn" {
   description = "FQDN of the DNS record of the Teleport server."
-  value       = "${aws_route53_record.teleport.fqdn}"
+  value       = aws_route53_record.teleport.fqdn
 }
 
 output "teleport_server_instance_profile_id" {
   description = "Instance profile id of the Teleport server."
-  value       = "${aws_iam_instance_profile.profile.id}"
+  value       = aws_iam_instance_profile.profile.id
 }
 
 output "teleport_server_instance_profile_arn" {
   description = "Instance profile ARN of the Teleport server."
-  value       = "${aws_iam_instance_profile.profile.arn}"
+  value       = aws_iam_instance_profile.profile.arn
 }
 
 output "teleport_server_instance_profile_name" {
   description = "Instance profile name of the Teleport server."
-  value       = "${aws_iam_instance_profile.profile.name}"
+  value       = aws_iam_instance_profile.profile.name
 }
 
 output "teleport_server_role_id" {
   description = "Role id of the Teleport server."
-  value       = "${aws_iam_role.role.unique_id}"
+  value       = aws_iam_role.role.unique_id
 }
 
 output "teleport_server_role_arn" {
   description = "Role ARN of the Teleport server."
-  value       = "${aws_iam_role.role.arn}"
+  value       = aws_iam_role.role.arn
 }
 
 output "teleport_server_role_name" {
   description = "Role name of the Teleport server."
-  value       = "${aws_iam_role.role.name}"
+  value       = aws_iam_role.role.name
 }

--- a/teleport-server/r53.tf
+++ b/teleport-server/r53.tf
@@ -1,7 +1,11 @@
 resource "aws_route53_record" "teleport" {
-  zone_id = "${data.aws_route53_zone.root.zone_id}"
-  name    = "${local.teleport_domain_name}"
+  zone_id = data.aws_route53_zone.root.zone_id
+  name    = local.teleport_domain_name
   type    = "CNAME"
-  records = ["${format("ec2-%s.%s.compute.amazonaws.com", replace(aws_eip.teleport_public.public_ip, ".", "-"), data.aws_region.current.name)}"] # Haven't found a better way to get the public_dns of the EIP
-  ttl     = "300"
+  records = [format(
+    "ec2-%s.%s.compute.amazonaws.com",
+    replace(aws_eip.teleport_public.public_ip, ".", "-"),
+    data.aws_region.current.name,
+  )] # Haven't found a better way to get the public_dns of the EIP
+  ttl = "300"
 }

--- a/teleport-server/s3.tf
+++ b/teleport-server/s3.tf
@@ -2,8 +2,8 @@ resource "aws_s3_bucket" "sessions" {
   bucket = "teleport-sessions-${var.project}-${var.environment}"
   acl    = "private"
 
-  tags {
+  tags = {
     Name        = "teleport-sessions-${var.project}-${var.environment}"
-    Environment = "${var.environment}"
+    Environment = var.environment
   }
 }

--- a/teleport-server/sg.tf
+++ b/teleport-server/sg.tf
@@ -1,11 +1,11 @@
 resource "aws_security_group" "teleport_server" {
   name_prefix = "teleport_server_"
   description = "Teleport server specific rules"
-  vpc_id      = "${data.aws_subnet.teleport.vpc_id}"
+  vpc_id      = data.aws_subnet.teleport.vpc_id
 
-  tags {
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
+  tags = {
+    Project     = var.project
+    Environment = var.environment
   }
 }
 
@@ -15,8 +15,8 @@ resource "aws_security_group_rule" "teleport_auth_from_nodes" {
   from_port         = 3025
   to_port           = 3025
   protocol          = "tcp"
-  cidr_blocks       = ["${var.allowed_node_cidr_blocks}"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  cidr_blocks       = var.allowed_node_cidr_blocks
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_auth_from_proxy_self" {
@@ -25,7 +25,7 @@ resource "aws_security_group_rule" "teleport_auth_from_proxy_self" {
   to_port           = 3025
   protocol          = "tcp"
   self              = "true"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_proxy_to_auth_self" {
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "teleport_proxy_to_auth_self" {
   to_port           = 3025
   protocol          = "tcp"
   self              = "true"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 ########## Proxy related rules
@@ -43,8 +43,8 @@ resource "aws_security_group_rule" "teleport_ssh_proxy_from_world" {
   from_port         = 3023
   to_port           = 3023
   protocol          = "tcp"
-  cidr_blocks       = ["${var.allowed_cli_cidr_blocks}"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  cidr_blocks       = var.allowed_cli_cidr_blocks
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_reverse_ssh_proxy_from_world" {
@@ -52,8 +52,8 @@ resource "aws_security_group_rule" "teleport_reverse_ssh_proxy_from_world" {
   from_port         = 3024
   to_port           = 3024
   protocol          = "tcp"
-  cidr_blocks       = ["${var.allowed_tunnel_cidr_blocks}"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  cidr_blocks       = var.allowed_tunnel_cidr_blocks
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_https_proxy_from_world" {
@@ -61,8 +61,8 @@ resource "aws_security_group_rule" "teleport_https_proxy_from_world" {
   from_port         = 3080
   to_port           = 3080
   protocol          = "tcp"
-  cidr_blocks       = ["${var.allowed_web_cidr_blocks}"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  cidr_blocks       = var.allowed_web_cidr_blocks
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 # These are needed for the trusted clusters feature, the auth server needs to connect to upstream Teleport clusters
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "teleport_https_auth_to_world" {
   to_port           = 3080
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_reverse_ssh_proxy_to_world" {
@@ -81,7 +81,7 @@ resource "aws_security_group_rule" "teleport_reverse_ssh_proxy_to_world" {
   to_port           = 3024
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 # Used by letsencrypt to obtain a certificate
@@ -91,7 +91,7 @@ resource "aws_security_group_rule" "teleport_le_http_proxy_from_world" {
   to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_le_https_proxy_from_world" {
@@ -100,7 +100,7 @@ resource "aws_security_group_rule" "teleport_le_https_proxy_from_world" {
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 ############## Node related rules
@@ -109,8 +109,8 @@ resource "aws_security_group_rule" "teleport_proxy_to_nodes" {
   from_port         = 3022
   to_port           = 3022
   protocol          = "tcp"
-  cidr_blocks       = ["${var.allowed_node_cidr_blocks}"]
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  cidr_blocks       = var.allowed_node_cidr_blocks
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_proxy_to_nodes_self" {
@@ -119,7 +119,7 @@ resource "aws_security_group_rule" "teleport_proxy_to_nodes_self" {
   to_port           = 3022
   protocol          = "tcp"
   self              = "true"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 resource "aws_security_group_rule" "teleport_nodes_from_proxy_self" {
@@ -128,7 +128,7 @@ resource "aws_security_group_rule" "teleport_nodes_from_proxy_self" {
   to_port           = 3022
   protocol          = "tcp"
   self              = "true"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
 }
 
 ############## General rules
@@ -137,7 +137,7 @@ resource "aws_security_group_rule" "internet_http_access" {
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
@@ -146,7 +146,7 @@ resource "aws_security_group_rule" "internet_https_access" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
@@ -156,6 +156,6 @@ resource "aws_security_group_rule" "ntp" {
   from_port         = 123
   to_port           = 123
   protocol          = "udp"
-  security_group_id = "${aws_security_group.teleport_server.id}"
+  security_group_id = aws_security_group.teleport_server.id
   cidr_blocks       = ["0.0.0.0/0"]
 }

--- a/teleport-server/variables.tf
+++ b/teleport-server/variables.tf
@@ -1,109 +1,132 @@
 variable "project" {
+  type        = string
   description = "A project where this setup belongs to. Only for naming reasons"
 }
 
 variable "environment" {
+  type        = string
   description = "The environment where this setup belongs to. Only for naming reasons"
 }
 
 variable "subnet_id" {
+  type        = string
   description = "Subnet id where the EC2 instance will be deployed"
 }
 
 variable "key_name" {
+  type        = string
   description = "SSH key name for the EC2 instance"
 }
 
 variable "r53_zone" {
+  type        = string
   description = "The Route53 zone where to add the Teleport DNS record"
 }
 
 variable "ami_id" {
+  type        = string
   description = "AMI id for the EC2 instance"
   default     = ""
 }
 
 variable "teleport_cluster_name" {
+  type        = string
   description = "Name of the teleport cluster"
   default     = ""
 }
 
 variable "teleport_dynamodb_table" {
+  type        = string
   description = "Name of the DynamoDB table to configure in Teleport"
   default     = ""
 }
 
 variable "instance_type" {
+  type        = string
   description = "Instance type for the EC2 instance"
   default     = "t2.small"
 }
 
 variable "letsencrypt_email" {
+  type        = string
   description = "Email to use to register to letsencrypt"
   default     = "letsencrypt@skyscrapers.eu"
 }
 
 variable "teleport_log_output" {
+  type        = string
   description = "Teleport logging configuration, possible values are `stdout`, `stderr` and `syslog`"
   default     = "stdout"
 }
 
 variable "teleport_log_severity" {
+  type        = string
   description = "Teleport logging configuration, possible severity values are `INFO`, `WARN` and `ERROR`"
   default     = "ERROR"
 }
 
 variable "teleport_auth_tokens" {
+  type        = list(string)
   description = "List of static tokens to configure in the Teleport server. **Note** that these tokens will be added \"as-is\" in the Teleport configuration, so they must be pre-fixed with the token type (e.g. `teleport_auth_tokens = [\"node:sdf34asd7f832efhsdnfsjdfh3i24788923r\"]`). See the official [documentation on static tokens](https://gravitational.com/teleport/docs/admin-guide/#static-tokens) for more info"
   default     = []
 }
 
 variable "teleport_session_recording" {
+  type        = string
   description = "Setting for configuring session recording in Teleport. Check the [official documentation](https://gravitational.com/teleport/docs/admin-guide/#configuration) for more info"
   default     = "node"
 }
 
 variable "allowed_node_cidr_blocks" {
+  type        = list(string)
   description = "CIDR blocks that are allowed to access the API interface in the `auth` server"
   default     = ["10.0.0.0/8"]
 }
 
 variable "allowed_cli_cidr_blocks" {
+  type        = list(string)
   description = "CIDR blocks that are allowed to access the cli interface of the `proxy` server"
   default     = ["0.0.0.0/0"]
 }
 
 variable "allowed_web_cidr_blocks" {
+  type        = list(string)
   description = "CIDR blocks that are allowed to access the web interface of the `proxy` server"
   default     = ["0.0.0.0/0"]
 }
 
 variable "allowed_tunnel_cidr_blocks" {
+  type        = list(string)
   description = "CIDR blocks that are allowed to access the reverse tunnel interface of the `proxy` server"
   default     = ["0.0.0.0/0"]
 }
 
 variable "root_vl_type" {
+  type        = string
   description = "Volume type for the root volume of the EC2 instance. Can be `standard`, `gp2`, or `io1`"
   default     = "gp2"
 }
 
 variable "root_vl_size" {
+  type        = number
   description = "Volume size for the root volume of the EC2 instance, in gigabytes"
   default     = 16
 }
 
 variable "root_vl_delete" {
+  type        = bool
   description = "Whether the root volume of the EC2 instance should be destroyed on instance termination"
-  default     = "true"
+  default     = true
 }
 
 variable "acme_server" {
+  type        = string
   description = "ACME server where to point `certbot` on the Teleport server to fetch an SSL certificate. Useful if you want to point to the letsencrypt staging server"
   default     = "https://acme-v01.api.letsencrypt.org/directory"
 }
 
 variable "teleport_subdomain" {
+  type        = string
   description = "DNS subdomain that will be created for the teleport server"
   default     = "teleport"
 }

--- a/teleport-server/versions.tf
+++ b/teleport-server/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This migrates the module to use the new Terraform 0.12 syntax.

Most of these changes come from the `terraform 0.12upgrade` command, with some additional ones that I've done manually.

I've only tested the `teleport-bootstrap-script` and `teleport-node-sg-rules` modules as part of the k8s stack, but all modules pass the `terraform validate` command.

I'll create a major release for this (5.0.0)