### PR TITLE
switch to default null for optional variables

### DIFF
--- a/teleport-server/instance.tf
+++ b/teleport-server/instance.tf
@@ -4,7 +4,7 @@ module "is_ebs_optimised" {
 }
 
 resource "aws_instance" "teleport_instance" {
-  ami                         = length(var.ami_id) > 0 ? var.ami_id : join("", data.aws_ami.teleport_ami.*.image_id)
+  ami                         = coalesce(var.ami_id, join("", data.aws_ami.teleport_ami.*.image_id))
   instance_type               = var.instance_type
   key_name                    = var.key_name
   iam_instance_profile        = aws_iam_instance_profile.profile.id

--- a/teleport-server/meta.tf
+++ b/teleport-server/meta.tf
@@ -1,7 +1,7 @@
 locals {
   teleport_domain_name    = "${var.teleport_subdomain}.${var.r53_zone}"
-  teleport_dynamodb_table = length(var.teleport_dynamodb_table) > 0 ? var.teleport_dynamodb_table : local.teleport_domain_name
-  teleport_cluster_name   = length(var.teleport_cluster_name) > 0 ? var.teleport_cluster_name : local.teleport_domain_name
+  teleport_dynamodb_table = coalesce(var.teleport_dynamodb_table, local.teleport_domain_name)
+  teleport_cluster_name   = coalesce(var.teleport_cluster_name, local.teleport_domain_name)
 }
 
 data "aws_region" "current" {
@@ -16,7 +16,7 @@ data "aws_subnet" "teleport" {
 }
 
 data "aws_ami" "teleport_ami" {
-  count       = length(var.ami_id) > 0 ? 0 : 1
+  count       = var.ami_id != null ? 0 : 1
   most_recent = true
 
   name_regex = "^ebs-teleport-*"

--- a/teleport-server/variables.tf
+++ b/teleport-server/variables.tf
@@ -26,19 +26,19 @@ variable "r53_zone" {
 variable "ami_id" {
   type        = string
   description = "AMI id for the EC2 instance"
-  default     = ""
+  default     = null
 }
 
 variable "teleport_cluster_name" {
   type        = string
   description = "Name of the teleport cluster"
-  default     = ""
+  default     = null
 }
 
 variable "teleport_dynamodb_table" {
   type        = string
   description = "Name of the DynamoDB table to configure in Teleport"
-  default     = ""
+  default     = null
 }
 
 variable "instance_type" {


### PR DESCRIPTION
after adding terraform 0.12 support we can now use null as default for optional variables instead of empty strings

as per: https://github.com/skyscrapers/teleport-server-stack/pull/9