### PR TITLE
Simplify auth token configuration

### DIFF
--- a/teleport-server/instance.tf
+++ b/teleport-server/instance.tf
@@ -48,19 +48,13 @@ data "template_file" "cloudinit_teleport" {
   template = file("${path.module}/templates/cloud-init.yaml.tpl")
 
   vars = {
-    letsencrypt_email        = var.letsencrypt_email
-    teleport_domain_name     = local.teleport_domain_name
-    teleport_log_output      = var.teleport_log_output
-    teleport_log_severity    = var.teleport_log_severity
-    teleport_dynamodb_region = data.aws_region.current.name
-    teleport_dynamodb_table  = local.teleport_dynamodb_table
-    teleport_auth_tokens = length(var.teleport_auth_tokens) > 0 ? indent(
-      6,
-      join(
-        "\n",
-        concat(["tokens:"], formatlist("- %s", var.teleport_auth_tokens)),
-      ),
-    ) : ""
+    letsencrypt_email             = var.letsencrypt_email
+    teleport_domain_name          = local.teleport_domain_name
+    teleport_log_output           = var.teleport_log_output
+    teleport_log_severity         = var.teleport_log_severity
+    teleport_dynamodb_region      = data.aws_region.current.name
+    teleport_dynamodb_table       = local.teleport_dynamodb_table
+    teleport_auth_tokens          = jsonencode(var.teleport_auth_tokens)
     teleport_cluster_name         = local.teleport_cluster_name
     teleport_session_recording    = var.teleport_session_recording
     acme_server                   = var.acme_server

--- a/teleport-server/templates/cloud-init.yaml.tpl
+++ b/teleport-server/templates/cloud-init.yaml.tpl
@@ -139,7 +139,9 @@ write_files:
     [Service]
     Type=simple
     Restart=on-failure
-    ExecStart=/usr/local/bin/teleport start -c /etc/teleport.yaml
+    ExecStart=/usr/local/bin/teleport start -c /etc/teleport.yaml --pid-file=/var/run/teleport.pid
+    ExecReload=/bin/kill -HUP $MAINPID
+    PIDFile=/var/run/teleport.pid
 
     [Install]
     WantedBy=multi-user.target

--- a/teleport-server/templates/cloud-init.yaml.tpl
+++ b/teleport-server/templates/cloud-init.yaml.tpl
@@ -67,7 +67,7 @@ write_files:
       #
       # We recommend to use tools like `pwgen` to generate sufficiently random
       # tokens of 32+ byte length.
-      ${teleport_auth_tokens}
+      tokens: ${teleport_auth_tokens}
 
       # Optional "cluster name" is needed when configuring trust between multiple
       # auth servers. A cluster name is used as part of a signature in certificates


### PR DESCRIPTION
Given that var.teleport_auth_tokens is a list of strings, and that json is a subset of yaml, we can directly encode them as json in the teleport config file