### PR TITLE
Use the attribute from the EIP resource to get the public DNS record

### DIFF
--- a/teleport-server/r53.tf
+++ b/teleport-server/r53.tf
@@ -2,10 +2,6 @@ resource "aws_route53_record" "teleport" {
   zone_id = data.aws_route53_zone.root.zone_id
   name    = local.teleport_domain_name
   type    = "CNAME"
-  records = [format(
-    "ec2-%s.%s.compute.amazonaws.com",
-    replace(aws_eip.teleport_public.public_ip, ".", "-"),
-    data.aws_region.current.name,
-  )] # Haven't found a better way to get the public_dns of the EIP
-  ttl = "300"
+  records = [aws_eip.teleport_public.public_dns] # This way it resolves to the instance private IP within the VPC
+  ttl     = "300"
 }


### PR DESCRIPTION
DNS records in us-east-1 look different, as they don't include the region part. Now that the aws_eip resource provides with the `public_dns` attribute, we'll just use that instead of the current "hack"