### PR TITLE
Block public S3 access completely

### DIFF
--- a/teleport-server/s3.tf
+++ b/teleport-server/s3.tf
@@ -7,3 +7,11 @@ resource "aws_s3_bucket" "sessions" {
     Environment = var.environment
   }
 }
+
+resource "aws_s3_bucket_public_access_block" "sessions" {
+  bucket                  = aws_s3_bucket.sessions.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
As we do with  most of our buckets these days, add `aws_s3_bucket_public_access_block` to enforce private access only.