### PR TITLE
Add KillMode=process to Teleport systemd file

### DIFF
--- a/teleport-bootstrap-script/templates/teleport.service.yaml
+++ b/teleport-bootstrap-script/templates/teleport.service.yaml
@@ -11,6 +11,8 @@
     ExecReload=/bin/kill -HUP $MAINPID
     PIDFile=/var/run/teleport.pid
     LimitNOFILE=65536
+    # https://github.com/gravitational/teleport/issues/2355
+    KillMode=process
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
We ran into this problem: https://github.com/gravitational/teleport/issues/2355.

Although the root cause of this happening, is a bad startup script by software not running with NOHUP. However we feel that setting `KillMode=process` on the Teleport systemd file is relatively safe as an extra failsafe.