### PR TITLE
Use IMDSv2 for AWS metadata

### DIFF
--- a/teleport-bootstrap-script/templates/metadata.tpl
+++ b/teleport-bootstrap-script/templates/metadata.tpl
@@ -3,8 +3,10 @@
 set -e
 
 get_private_ip () {
-  PRIVATE_IP="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
-  if [ $? != 0 ]; then
+  TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30")
+  PRIVATE_IP="$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)"
+
+  if [ -z $PRIVATE_IP ]; then
     # hostname -I returns all IP addresses available in the server, grep will return the first private IP found
     PRIVATE_IP="$(hostname -I | tr ' ' '\n' | grep -m 1 -E '^(192\.168|10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.)')"
   fi

--- a/teleport-bootstrap-script/templates/teleport.yaml.tpl
+++ b/teleport-bootstrap-script/templates/teleport.yaml.tpl
@@ -2,7 +2,8 @@ ssh_service:
   enabled: yes
   listen_addr: 0.0.0.0:3022
 
-  labels: ${labels}
+  labels:
+    ${labels}
 
   commands:
     - name: teleport_version

--- a/teleport-bootstrap-script/templates/teleport.yaml.tpl
+++ b/teleport-bootstrap-script/templates/teleport.yaml.tpl
@@ -2,15 +2,20 @@ ssh_service:
   enabled: yes
   listen_addr: 0.0.0.0:3022
 
-  labels:
-    ${labels}
+  labels: ${labels}
 
   commands:
     - name: teleport_version
-      command: ["/bin/bash", "-c", "/usr/local/bin/teleport version | cut -d' ' -f2"]
+      command:
+        ["/bin/bash", "-c", "/usr/local/bin/teleport version | cut -d' ' -f2"]
       period: 1h0m0s
     - name: instance_type
-      command: ["/usr/bin/curl", "-s", "http://169.254.169.254/latest/meta-data/instance-type"]
+      command:
+        [
+          "/bin/bash",
+          "-c",
+          'TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30") && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-type',
+        ]
       period: 1h0m0s
 
   permit_user_env: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->

Currently the bootstrap script will silently continue, but with an empty `$PRIVATE_IP` when IMDSv2 is forced for the EC2 instance. This change makes sure to get an IMDSv2 token for accessing the metadata service, and will also continue to the fallback method if `$PRIVATE_IP` is empty.

# Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/skyscrapers/engineering/issues/1021

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken script when IMDSv2 is required.

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual run on our nodes, both with IMDSv2 enforced and not enforced. 

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the PR process as described [here](https://github.com/skyscrapers/documentation/blob/master/coding_guidelines/git.md#pull-requests)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
